### PR TITLE
docs(blog): editorial improvements to introducing post

### DIFF
--- a/docs-src/pages/blog/2026-03-09-introducing-le-truc.md
+++ b/docs-src/pages/blog/2026-03-09-introducing-le-truc.md
@@ -11,13 +11,13 @@ tags: release, announcement
 {% section %}
 ## Building on sand
 
-Around three years ago, we sat down at Zeix and looked honestly at our frontend projects. What we saw made us uncomfortable.
+Three years ago, we sat down at Zeix and looked honestly at our frontend projects. What we saw made us uncomfortable.
 
 On one side were the legacy projects: jQuery, Bootstrap, IIFE modules, Vanilla JS. These had been perfectly reasonable choices at the time. But as features accumulated, components became entangled. Imperative wiring had quietly spread through the codebase until refactoring anything required understanding everything. The code worked, but it resisted change.
 
 On the other side were the SPA projects: Angular, React, Vue. These had better separation of concerns — reactivity meant components stayed decoupled and updates were predictable. But there was a different kind of friction. Every two to three years, a major API overhaul. Patterns that had become second nature suddenly deprecated, replaced by something that required relearning the mental model from scratch. And components built for Vue couldn't be reused in a React project, sometimes not even across major versions of the same framework.
 
-Neither world felt sustainable. We build for clients who need their solutions to last five to ten years. Picking any of these paths meant accepting that a future storm — a framework pivot, an end of life, a paradigm shift — could sweep away the foundation and generate costs and effort at the worst possible moment. We were building on sand.
+Neither world felt sustainable. We build for clients who need their solutions to last five to ten years. Picking any of these paths meant accepting that a future storm — a framework pivot, an end of life, a paradigm shift — could sweep away the foundation and arrive at the worst possible moment. We were building on sand.
 
 ## What we tried
 
@@ -27,7 +27,7 @@ Web Components were the obvious starting point. A platform-native component mode
 
 We looked at the lighter-weight options too. HTMX and Alpine were appealing in spirit, but controlling interactivity by scattering HTML attributes across arbitrary elements doesn't give you component boundaries, and there's no compile-time type safety to catch integration mistakes early. WebC and Enhance were interesting experiments, but they required a JavaScript layer on the backend — a non-starter when your backends are PHP, Java, C#, or Python — and they didn't offer client-side reactivity anyway.
 
-Meanwhile, SPA frameworks were pivoting to server-side rendering. When I finally worked through how React Server Components actually function, I understood the reasoning. But the solution felt like a reductio ad absurdum: an ever more elaborate architecture to paper over a problem that had been introduced by the architecture itself.
+Meanwhile, SPA frameworks were pivoting to server-side rendering. When we finally worked through how React Server Components actually function, we understood the reasoning. But the solution felt like an ever more elaborate architecture to paper over a problem that had been introduced by the architecture itself.
 
 ## The root cause
 
@@ -35,7 +35,7 @@ That last observation forced a more fundamental question: where does the problem
 
 When we built sites with PHP and jQuery, we didn't have a double-data or double-template problem. The server rendered HTML correctly. The browser displayed it. JavaScript added interactivity where needed. That was it. The web platform did its job.
 
-The double-data problem — sending both a rendered HTML fragment and the JSON data required to re-render it — is not a property of web development in general. It's a consequence of a specific architectural choice: complecting client-side rendering with data flow. Once a framework takes over rendering on the client, it owns the component lifecycle, and now it needs to be able to re-render from scratch. JSON data and JS templates must travel to the browser. SSR becomes a workaround to get HTML on the initial load, while the framework re-takes control during hydration.
+The double-data problem — sending both a rendered HTML fragment and the JSON data required to re-render it — is not a property of web development in general. It's a consequence of a specific architectural choice: entangling client-side rendering with data flow. Once a framework takes over rendering on the client, it owns the component lifecycle, and now it needs to be able to re-render from scratch. JSON data and JS templates must travel to the browser. SSR becomes a workaround to get HTML on the initial load, while the framework re-takes control during hydration.
 
 Vanilla JS doesn't have this problem. PHP didn't have this problem. The problem was introduced by SPA frameworks, and their proposed solutions — Server Components, islands, partial hydration — are attempts to claw back what was given up.
 
@@ -51,11 +51,11 @@ For components, we use the Web Components standard. Custom elements are genuinel
 
 ## From CodePen to 1.0
 
-We started in early 2024 with a proof of concept in CodePen — a few hundred lines of JavaScript, no build tools, just enough to verify that the approach was feasible. The early version was clever. It used signals, leaned on the fact that arrays are monads in JavaScript, and worked — as long as developers handled errors externally and were comfortable with implicit type coercion.
+We started in early 2024 with a proof of concept in CodePen — a few hundred lines of JavaScript, no build tools, just enough to verify that the approach was feasible. The early version was clever. It used signals and worked — as long as developers handled errors externally and were comfortable with implicit type coercion.
 
 Clever turned out to be the wrong property to optimize for. We spent the following year making Le Truc less clever and more robust. Type safety became a central concern. The DOM is an external world: unlike a framework that controls the full component lifecycle, we had to infer types from selector strings, attribute values, and element queries that could return anything. Getting compile-time type inference to work — so that `first('button')` returns `HTMLButtonElement` and `first('input[type="text"]')` returns `HTMLInputElement` — required building a type-level CSS selector parser in TypeScript. It was not on the original roadmap. It turned out to be worth it.
 
-We also separated the reactive primitives into their own library, `@zeix/cause-effect`, for a reason that still matters: if the TC39 signals proposal matures, or a faster signals implementation appears, we can swap the foundation without rewriting Le Truc. (Benchmarks along the way surprised us — our implementation turned out faster than Angular, Vue, Svelte, and Solid 1.0 signals at the time. Performance is no longer our unique claim, but colorless async and specialized primitives like `Slot`, `Sensor`, and `Store` are.)
+We also separated the reactive primitives into their own library, `@zeix/cause-effect`, for a reason that still matters: if the TC39 signals proposal matures, or a faster signals implementation appears, we can swap the foundation without rewriting Le Truc.
 
 One mechanism we're particularly proud of: `pass()`. In most component models, sharing state between parent and child means prop drilling — passing values through a chain of components, each re-rendering on change. In Le Truc, when a parent passes a signal to a child Le Truc component, they share the same underlying signal node. There's no intermediate effect, no copying of values, no chain of renders. The child always has direct access to the current value, one hop away. The coordinating parent can be application-specific; the receiving component stays generic, with no knowledge of where its reactive value comes from.
 


### PR DESCRIPTION
Tighten voice and remove passages that don't serve the narrative:
- Remove hedging ("Around" → "Three years ago")
- Fix pronoun inconsistency ("I" → "we")
- Replace jargon ("complecting" → "entangling", remove "reductio ad absurdum")
- Cut monads aside and self-defeating benchmarks parenthetical