### PR TITLE
fix(bindings): strip C0 controls in isSafeURL before scheme checks

### DIFF
--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -62,9 +62,10 @@ const SCRIPT_ATTRS = [
 /**
  * Check whether a URL string is safe to use as an attribute value.
  *
- * Rejects `javascript:`, `data:`, and `vbscript:` schemes (including internal
- * whitespace variants such as `java\tscript:`, which browsers canonicalize before
- * parsing the scheme). Rejects protocol-relative URLs (`//host`) and backslash
+ * Rejects `javascript:`, `data:`, and `vbscript:` schemes (including variants
+ * masked by C0 control characters or whitespace, such as `\x01javascript:` or
+ * `java\tscript:`, which browsers strip/canonicalize before parsing the scheme).
+ * Rejects protocol-relative URLs (`//host`) and backslash
  * variants (`\\host`), which resolve against the page origin. Allows relative
  * paths, fragments, query strings, `mailto:`, `tel:`, and absolute URLs with
  * `http:`, `https:`, or `ftp:` protocols.
@@ -72,13 +73,20 @@ const SCRIPT_ATTRS = [
  * @param {string} value - URL string to validate
  * @returns {boolean} `true` if the URL is considered safe, `false` otherwise
  */
+const stripC0AndSpace = (value: string): string => {
+	let out = ''
+	for (let i = 0; i < value.length; i++) {
+		if (value.charCodeAt(i) > 0x20) out += value[i]!
+	}
+	return out
+}
+
 const isSafeURL = (value: string): boolean => {
-	// Strip ALL ASCII whitespace, not just edges. Browsers ignore internal
-	// tab/newline/CR when parsing URL schemes, so "java\tscript:" would otherwise
-	// slip past the `^javascript:` check below and execute.
-	const stripped = String(value)
-		.replace(/[\t\n\r\f\v]/g, '')
-		.trim()
+	// Strip the full C0 control + ASCII space range (U+0000–U+0020). Browsers
+	// strip leading controls before parsing schemes; internal tab/newline/CR are
+	// also ignored — without this, "\x01javascript:" or "java\tscript:" slip past
+	// the `^javascript:` check below and execute on activation.
+	const stripped = stripC0AndSpace(String(value))
 	if (/^(javascript|data|vbscript):/i.test(stripped)) return false
 	if (/^(mailto|tel):/i.test(stripped)) return true
 	// Protocol-relative (//host) and backslash-prefixed (\\host) URLs resolve

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -73,20 +73,13 @@ const SCRIPT_ATTRS = [
  * @param {string} value - URL string to validate
  * @returns {boolean} `true` if the URL is considered safe, `false` otherwise
  */
-const stripC0AndSpace = (value: string): string => {
-	let out = ''
-	for (let i = 0; i < value.length; i++) {
-		if (value.charCodeAt(i) > 0x20) out += value[i]!
-	}
-	return out
-}
-
 const isSafeURL = (value: string): boolean => {
 	// Strip the full C0 control + ASCII space range (U+0000–U+0020). Browsers
 	// strip leading controls before parsing schemes; internal tab/newline/CR are
 	// also ignored — without this, "\x01javascript:" or "java\tscript:" slip past
 	// the `^javascript:` check below and execute on activation.
-	const stripped = stripC0AndSpace(String(value))
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping C0 controls is the point, not a typo
+	const stripped = String(value).replace(/[\x00-\x20]/g, '')
 	if (/^(javascript|data|vbscript):/i.test(stripped)) return false
 	if (/^(mailto|tel):/i.test(stripped)) return true
 	// Protocol-relative (//host) and backslash-prefixed (\\host) URLs resolve

--- a/src/tests/bindings.test.ts
+++ b/src/tests/bindings.test.ts
@@ -309,6 +309,20 @@ describe('safeSetAttribute', () => {
 		).toThrow()
 	})
 
+	test('blocks javascript: with leading C0 control characters (regression: A2)', () => {
+		// Browsers strip leading U+0000–U+001F before parsing schemes. Tab/LF/CR
+		// are covered above; this catches the remaining C0 range (0x00–0x08,
+		// 0x0E–0x1F) that neither the old [\t\n\r\f\v] regex nor trim() removed.
+		const codes = [
+			...Array.from({ length: 9 }, (_, i) => i),
+			...Array.from({ length: 18 }, (_, i) => i + 0x0e),
+		]
+		for (const code of codes) {
+			const payload = String.fromCharCode(code) + 'javascript:alert(1)'
+			expect(() => safeSetAttribute(makeEl(), 'href', payload)).toThrow()
+		}
+	})
+
 	test('blocks protocol-relative URL //host (regression: A2)', () => {
 		// "//evil.com" contains no "://", so it previously fell through to the
 		// allow-by-default return and resolved against the page origin.


### PR DESCRIPTION
Leading U+0000–U+001F bytes could mask javascript: URLs that pass validation but execute once the browser strips controls on activation. Extend stripping beyond tab/newline to the full C0+space range and add regression tests.