### PR TITLE
fix(pass): defer setup when a defined custom-element child was queried

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.3.1
+
+### Fixed
+
+- **`resolveDependencies` now defers setup when `first()`/`all()` queried a `:defined` custom-element child**: previously, dependency resolution deferred the callback only for *not-yet-defined* custom elements (those awaiting `customElements.whenDefined()`). But when a whole nested parent+child subtree is built detached and appended in a single operation, the browser queues each element's `connectedCallback` in tree order — the parent's fires *first*. The child is already `:defined` (its class is registered) yet its own `connectedCallback` — and therefore its `expose()`/Slot setup — has not run. When the parent's effects then ran synchronously, `pass()` → `swapSlots` threw `InvalidPassPropertyError` because `'prop' in child` was still `false`. `makeElementQueries` now tracks whether `first()`/`all()` matched any `:defined` custom-element descendant, and `resolveDependencies` defers the callback to a microtask whenever that flag is set, letting the child's queued `connectedCallback` drain first so its properties are ready before the parent reads them. Plain element children still resolve synchronously. This is distinct from the `DEPENDENCY_TIMEOUT` race — it covers a child that is *already* defined but not yet initialized.
+
 ## 2.3.0
 
 ### Added

--- a/index.js
+++ b/index.js
@@ -2285,12 +2285,15 @@ function createElementsMemo(parent, selector) {
 var makeElementQueries = (host) => {
   const root = host.shadowRoot ?? host;
   const dependencies = new Set;
+  let queriedDefinedCustomChild = false;
   function first(selector, required) {
     const target = root.querySelector(selector);
     if (required != null && !target)
       throw new MissingElementError(host, selector, required);
     if (target && isNotYetDefinedComponent(target))
       dependencies.add(target.localName);
+    else if (target && isCustomElement(target))
+      queriedDefinedCustomChild = true;
     return target ?? undefined;
   }
   function all(selector, required) {
@@ -2302,11 +2305,13 @@ var makeElementQueries = (host) => {
       for (const target of current) {
         if (isNotYetDefinedComponent(target))
           dependencies.add(target.localName);
+        else if (isCustomElement(target))
+          queriedDefinedCustomChild = true;
       }
     return targets;
   }
   const resolveDependencies = (callback) => {
-    if (dependencies.size) {
+    if (dependencies.size || queriedDefinedCustomChild) {
       queueMicrotask(() => {
         const deps = Array.from(dependencies).filter((dep) => !customElements.get(dep));
         if (!deps.length) {

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-// Le Truc 2.3.0
+// Le Truc 2.3.1
 
 // From Cause & Effect
 export {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zeix/le-truc",
-	"version": "2.3.0",
+	"version": "2.3.1",
 	"description": "Le Truc - the thing for type-safe reactive web components",
 	"keywords": [
 		"Le Truc",

--- a/src/helpers/dom.ts
+++ b/src/helpers/dom.ts
@@ -5,7 +5,7 @@ import {
 	MissingElementError,
 } from '../errors'
 import { DEPENDENCY_TIMEOUT } from '../internal'
-import { isNotYetDefinedComponent } from '../util'
+import { isCustomElement, isNotYetDefinedComponent } from '../util'
 
 /* === Types === */
 
@@ -244,6 +244,15 @@ const makeElementQueries = (
 ): [ElementQueries, (run: () => void) => void] => {
 	const root = host.shadowRoot ?? host
 	const dependencies: Set<string> = new Set()
+	// True when `first()`/`all()` matched any `:defined` custom-element
+	// descendant. The element's class is already registered, but when a whole
+	// nested subtree is connected in one operation (e.g. a framework building
+	// it detached then appending), the browser queues each element's
+	// connectedCallback in tree order — the parent's runs first, before the
+	// child's own setup (expose()/Slot accessors) has run. Deferring setup by
+	// one microtask lets the child's queued connectedCallback drain first, so
+	// `pass()` → `swapSlots` finds the child's properties ready.
+	let queriedDefinedCustomChild = false
 
 	/**
 	 * Return the first descendant element matching a CSS selector.
@@ -277,6 +286,7 @@ const makeElementQueries = (
 		// Only add to dependencies if element is a custom element that's not yet defined
 		if (target && isNotYetDefinedComponent(target))
 			dependencies.add(target.localName)
+		else if (target && isCustomElement(target)) queriedDefinedCustomChild = true
 		return target ?? undefined
 	}
 
@@ -314,6 +324,7 @@ const makeElementQueries = (
 			for (const target of current) {
 				// Only add to dependencies if element is a custom element that's not yet defined
 				if (isNotYetDefinedComponent(target)) dependencies.add(target.localName)
+				else if (isCustomElement(target)) queriedDefinedCustomChild = true
 			}
 		return targets
 	}
@@ -321,9 +332,15 @@ const makeElementQueries = (
 	/**
 	 * Wait for all collected custom element dependencies to be defined, then run `callback`.
 	 *
-	 * If no dependencies were collected, `callback` runs synchronously. Otherwise, a
-	 * microtask filters out already-defined elements, then `Promise.all` awaits the rest
-	 * with a 200 ms timeout (see `DEPENDENCY_TIMEOUT`).
+	 * If no dependencies were collected and no `:defined` custom-element child was queried,
+	 * `callback` runs synchronously. Otherwise, a microtask filters out already-defined
+	 * elements, then `Promise.all` awaits the rest with a 200 ms timeout
+	 * (see `DEPENDENCY_TIMEOUT`). The microtask deferral also covers the case where a
+	 * `:defined` custom-element child was queried: its class is registered but its own
+	 * `connectedCallback` may not have run yet when a nested subtree is connected in one
+	 * operation (parent's callback fires first, in tree order). Letting the microtask
+	 * drain first ensures the child's `expose()`/Slot setup is complete before the
+	 * parent's effects (e.g. `pass()` → `swapSlots`) read the child's properties.
 	 *
 	 * On timeout, a `DependencyTimeoutError` is logged in DEV_MODE and `callback` runs
 	 * anyway — effects proceed in a degraded-but-functional state. A single undefined
@@ -333,7 +350,7 @@ const makeElementQueries = (
 	 * @param {() => void} callback - Function to run once dependencies are resolved (or timed out)
 	 */
 	const resolveDependencies = (callback: () => void) => {
-		if (dependencies.size) {
+		if (dependencies.size || queriedDefinedCustomChild) {
 			// Defer to microtask to filter out components that get defined
 			// synchronously after queries ran (e.g. co-bundled components
 			// whose define() calls execute later in the same script).

--- a/src/tests/dom.test.ts
+++ b/src/tests/dom.test.ts
@@ -132,3 +132,129 @@ describe('resolveDependencies timeout path', () => {
 		}
 	}, 1000)
 })
+
+describe('resolveDependencies defers for a registered-but-uninitialized child', () => {
+	// Regression for the detached-subtree timing bug: when a whole nested
+	// parent+child subtree is built detached then appended in one operation
+	// (e.g. lit-html/Storybook's render path), the browser queues the
+	// connectedCallbacks in tree order — the parent's fires first. The child
+	// is already `:defined` (its class is registered) but its own
+	// connectedCallback — and therefore its expose()/Slot setup — hasn't run
+	// yet. If `resolveDependencies` runs the parent's setup (which calls
+	// `pass()` → `swapSlots`) synchronously, `pass()` throws
+	// `InvalidPassPropertyError` because `'prop' in child` is still false.
+	//
+	// Fix: when `first()`/`all()` query any `:defined` custom-element child,
+	// `resolveDependencies` must defer setup to a microtask so the child's
+	// queued connectedCallback drains first. No real DOM is available under
+	// `bun test`, so this verifies the deferral *mechanism*: a queried
+	// `:defined` custom element makes the callback run on a microtask, not
+	// synchronously. End-to-end browser verification was done separately.
+	test('defers the callback to a microtask when first() matches a defined custom element', async () => {
+		const originalCustomElements = (globalThis as any).customElements
+		;(globalThis as any).customElements = {
+			// The child's class IS registered (the precondition for the bug).
+			get: (_name: string) => function DefinedChild() {},
+			whenDefined: (_name: string) => Promise.resolve(),
+		}
+
+		try {
+			// A custom element that matches `:defined` (class registered) but
+			// whose own setup hasn't run yet — exactly the race window.
+			const definedChild = {
+				localName: 'defined-child',
+				matches: (selector: string) => selector !== ':not(:defined)',
+			} as unknown as Element
+			const host = {
+				localName: 'parent-host',
+				shadowRoot: null,
+				querySelector: (_selector: string) => definedChild,
+			} as unknown as HTMLElement
+
+			const [{ first }, resolveDependencies] = makeElementQueries(host)
+			first('defined-child')
+
+			const calls: string[] = []
+			resolveDependencies(() => calls.push('callback'))
+
+			// The callback must NOT have run synchronously — it must be
+			// deferred so the child's queued connectedCallback can drain first.
+			expect(calls).toEqual([])
+
+			// After the microtask drains, the callback runs exactly once.
+			await Promise.resolve()
+			expect(calls).toEqual(['callback'])
+		} finally {
+			;(globalThis as any).customElements = originalCustomElements
+		}
+	})
+
+	test('defers the callback to a microtask when all() matches a defined custom element', async () => {
+		const originalCustomElements = (globalThis as any).customElements
+		;(globalThis as any).customElements = {
+			get: (_name: string) => function DefinedChild() {},
+			whenDefined: (_name: string) => Promise.resolve(),
+		}
+
+		try {
+			const definedChild = {
+				localName: 'defined-child',
+				matches: (selector: string) => selector !== ':not(:defined)',
+				// createElementsMemo walks the parent via querySelectorAll
+				querySelector: () => null,
+				querySelectorAll: () => [] as unknown as NodeListOf<Element>,
+			} as unknown as Element
+			const host = {
+				localName: 'parent-host',
+				shadowRoot: null,
+				querySelector: () => null,
+				querySelectorAll: () =>
+					[definedChild] as unknown as NodeListOf<Element>,
+			} as unknown as HTMLElement
+
+			const [{ all }, resolveDependencies] = makeElementQueries(host)
+			all('defined-child')
+
+			const calls: string[] = []
+			resolveDependencies(() => calls.push('callback'))
+
+			expect(calls).toEqual([])
+			await Promise.resolve()
+			expect(calls).toEqual(['callback'])
+		} finally {
+			;(globalThis as any).customElements = originalCustomElements
+		}
+	})
+
+	test('runs the callback synchronously when no custom-element child was queried', () => {
+		// A plain (non-custom) element must not trigger the deferral.
+		const originalCustomElements = (globalThis as any).customElements
+		;(globalThis as any).customElements = {
+			get: (_name: string) => undefined,
+			whenDefined: (_name: string) => Promise.resolve(),
+		}
+
+		try {
+			const plainElement = {
+				localName: 'div', // not a custom element
+				matches: () => false,
+			} as unknown as Element
+			const host = {
+				localName: 'parent-host',
+				shadowRoot: null,
+				querySelector: (_selector: string) => plainElement,
+			} as unknown as HTMLElement
+
+			const [{ first }, resolveDependencies] = makeElementQueries(host)
+			first('div')
+
+			const calls: string[] = []
+			resolveDependencies(() => calls.push('callback'))
+
+			// No custom-element child → no deferral → synchronous.
+			expect(calls).toEqual(['callback'])
+		} finally {
+			;(globalThis as any).customElements = originalCustomElements
+		}
+	})
+})


### PR DESCRIPTION
### Fixed

- **`resolveDependencies` now defers setup when `first()`/`all()` queried a `:defined` custom-element child**: previously, dependency resolution deferred the callback only for *not-yet-defined* custom elements (those awaiting `customElements.whenDefined()`). But when a whole nested parent+child subtree is built detached and appended in a single operation, the browser queues each element's `connectedCallback` in tree order — the parent's fires *first*. The child is already `:defined` (its class is registered) yet its own `connectedCallback` — and therefore its `expose()`/Slot setup — has not run. When the parent's effects then ran synchronously, `pass()` → `swapSlots` threw `InvalidPassPropertyError` because `'prop' in child` was still `false`. `makeElementQueries` now tracks whether `first()`/`all()` matched any `:defined` custom-element descendant, and `resolveDependencies` defers the callback to a microtask whenever that flag is set, letting the child's queued `connectedCallback` drain first so its properties are ready before the parent reads them. Plain element children still resolve synchronously. This is distinct from the `DEPENDENCY_TIMEOUT` race — it covers a child that is *already* defined but not yet initialized.