### PR TITLE
Document formAssociated() form-control contract in example docs

### DIFF
--- a/examples/_common/form-associated.md
+++ b/examples/_common/form-associated.md
@@ -1,0 +1,66 @@
+{% collapsible title="Participates in HTML forms via formAssociated(), which installs the native-parity form-control contract." %}
+
+##### Properties
+
+{% table %}
+- Name
+- Type
+- Default
+- Description
+---
+- `disabled`
+- `boolean`
+- `false`
+- Whether the control is disabled; reflects the `disabled` attribute and inherits from an ancestor `<fieldset disabled>`
+---
+- `form`
+- `HTMLFormElement \| null` (readonly)
+- `null`
+- Owning `<form>` element, or `null` if none
+---
+- `labels`
+- `NodeList` (readonly)
+- empty `NodeList`
+- Associated `<label>` elements
+---
+- `name`
+- `string`
+- `''`
+- Form field name; reflects the `name` attribute
+---
+- `validationMessage`
+- `string` (readonly)
+- `''`
+- Current validation message
+---
+- `validity`
+- `ValidityState` (readonly)
+- valid
+- Current validation state
+---
+- `willValidate`
+- `boolean` (readonly)
+- `false`
+- Whether the control participates in constraint validation
+{% /table %}
+
+##### Methods
+
+{% table %}
+- Name
+- Type
+- Description
+---
+- `checkValidity`
+- `() => boolean`
+- Checks validity; returns `true` if valid
+---
+- `reportValidity`
+- `() => boolean`
+- Checks validity and reports the result to the user (e.g. validation bubble)
+---
+- `setCustomValidity`
+- `(message: string) => void`
+- Sets a custom validation error message; clears it when `message` is `''`
+{% /table %}
+{% /collapsible %}

--- a/examples/basic/gauge/basic-gauge.md
+++ b/examples/basic/gauge/basic-gauge.md
@@ -26,14 +26,19 @@ A visual gauge meter that parses the `thresholds` attribute which configures the
 - `number` (float)
 - `0`
 - Current gauge value; read from the `value` attribute (falling back to `<meter value="…">`) at connect time, and re-parsed on later `value` attribute mutations via `observedAttributes()`
----
-- `thresholds`
-- `BasicGaugeThreshold[]`
-- `[]`
-- Threshold ranges used to derive the active label and color; see below for format
 {% /table %}
 
-`BasicGaugeThreshold[]` is an array of objects sorted from highest to lowest `min`. Each entry has `min` (number), `label` (string), and `color` (CSS color string). The first entry whose `min` is ≤ `host.value` determines the active label and color. Example: `[{"min":80,"label":"Good job!","color":"var(--color-green-70)"},{"min":50,"label":"Decent","color":"var(--color-orange-70)"},{"min":0,"label":"Try again!","color":"var(--color-pink-70)"}]`
+#### Attributes
+
+{% table %}
+- Name
+- Description
+---
+- `thresholds`
+- Color-coded threshold ranges as a JSON array; read once at connect time. See below for format.
+{% /table %}
+
+`thresholds` is a `BasicGaugeThreshold[]`: an array of objects sorted from highest to lowest `min`. Each entry has `min` (number), `label` (string), and `color` (CSS color string). The first entry whose `min` is ≤ `host.value` determines the active label and color. Example: `[{"min":80,"label":"Good job!","color":"var(--color-green-70)"},{"min":50,"label":"Decent","color":"var(--color-orange-70)"},{"min":0,"label":"Try again!","color":"var(--color-pink-70)"}]`
 
 #### Descendant Elements
 

--- a/examples/form/checkbox/form-checkbox.md
+++ b/examples/form/checkbox/form-checkbox.md
@@ -1,6 +1,6 @@
 ### Form Checkbox
 
-A styledwrapper for a native checkbox with todo item and toggle switch variants.
+A styled wrapper for a native checkbox with todo item and toggle switch variants.
 
 #### Preview
 
@@ -32,6 +32,8 @@ A styledwrapper for a native checkbox with todo item and toggle switch variants.
 - Text content of `.label` or `label`
 - Label text shown next to the checkbox
 {% /table %}
+
+{% partial file="form-associated.md" /%}
 
 #### Classes
 

--- a/examples/form/colorgraph/form-colorgraph.md
+++ b/examples/form/colorgraph/form-colorgraph.md
@@ -43,6 +43,8 @@ An interactive OKLCH color picker combining a 2D lightness/chroma graph, a hue s
 - Hue angle in degrees (0–360)
 {% /table %}
 
+{% partial file="form-associated.md" /%}
+
 #### Methods
 
 {% table %}

--- a/examples/form/combobox/form-combobox.md
+++ b/examples/form/combobox/form-combobox.md
@@ -38,6 +38,8 @@ An advanced form component that coordinates a text input with a popup `form-list
 - Assistive/help text shown in `.description`
 {% /table %}
 
+{% partial file="form-associated.md" /%}
+
 #### Methods
 
 {% table %}

--- a/examples/form/inplace-edit/form-inplace-edit.md
+++ b/examples/form/inplace-edit/form-inplace-edit.md
@@ -33,6 +33,8 @@ A self-contained inline label editor. Wraps a `<span>` (label display) and an ed
 - Current label value; reactive — set via `pass()` to keep display in sync with external data
 {% /table %}
 
+{% partial file="form-associated.md" /%}
+
 #### Descendant Elements
 
 {% table %}

--- a/examples/form/listbox/form-listbox.md
+++ b/examples/form/listbox/form-listbox.md
@@ -43,6 +43,8 @@ A full-featured listbox with client-side filtering and optional remote option lo
 - URL for loading options JSON (flat or grouped)
 {% /table %}
 
+{% partial file="form-associated.md" /%}
+
 #### Descendant Elements
 
 {% table %}

--- a/examples/form/radiogroup/form-radiogroup.md
+++ b/examples/form/radiogroup/form-radiogroup.md
@@ -28,6 +28,8 @@ A roving-tabindex radio group that works both controlled and uncontrolled.
 - Value of the currently checked radio input; settable for controlled use
 {% /table %}
 
+{% partial file="form-associated.md" /%}
+
 #### Classes
 
 Use `class` attribute to get a different style for the radio group.

--- a/examples/form/spinbutton/form-spinbutton.md
+++ b/examples/form/spinbutton/form-spinbutton.md
@@ -33,6 +33,8 @@ A quantity spinbutton with increment/decrement buttons, clamped values, and keyb
 - Maximum allowed value (read from `input.max`)
 {% /table %}
 
+{% partial file="form-associated.md" /%}
+
 #### Descendant Elements
 
 {% table %}

--- a/examples/form/textbox/form-textbox.css
+++ b/examples/form/textbox/form-textbox.css
@@ -45,7 +45,7 @@ form-textbox {
 		height: var(--input-height);
 	}
 
-	&[clearable] .input {
+	&:state(clearable) .input {
 		position: relative;
 
 		& input {

--- a/examples/form/textbox/form-textbox.html
+++ b/examples/form/textbox/form-textbox.html
@@ -16,7 +16,7 @@
 
 <hr>
 
-<form-textbox name="query" clearable>
+<form-textbox name="query">
 	<label for="query-input">Search terms</label>
 	<div class="input">
 		<input

--- a/examples/form/textbox/form-textbox.md
+++ b/examples/form/textbox/form-textbox.md
@@ -1,6 +1,6 @@
 ### Form Textbox
 
-A general-purpose text field wrapper for `input` or `textarea` elements.
+A general-purpose text field wrapper for `input` or `textarea` elements. Sets the `:state(clearable)` custom state when a `button.clear` descendant is present, so CSS can reserve space for it.
 
 #### Preview
 
@@ -37,6 +37,8 @@ A general-purpose text field wrapper for `input` or `textarea` elements.
 - Text content of `.description`
 - Description/help text (or remaining characters when `data-remaining` is set)
 {% /table %}
+
+{% partial file="form-associated.md" /%}
 
 #### Methods
 

--- a/examples/form/textbox/form-textbox.ts
+++ b/examples/form/textbox/form-textbox.ts
@@ -35,12 +35,15 @@ declare global {
  * and validity are via ElementInternals (`formAssociated()`).
  * External consumers read `host.validationMessage` / `host.validity` like on a
  * native input; inline error display binds to component-internal state.
+ * Sets the `:state(clearable)` custom state when a `button.clear` descendant
+ * is present, so CSS can reserve space for it — derived from markup, not an
+ * author-set attribute, so it can't drift out of sync or be spoofed.
  *
  * @demo {https://zeixcom.github.io/le-truc/examples.html#form-textbox} Interactive preview and usage examples
  **/
 export default defineComponent<FormTextboxProps>(
 	'form-textbox',
-	({ expose, first, host, on, watch }) => {
+	({ expose, first, host, internals, on, watch }) => {
 		const textbox = first(
 			'input, textarea',
 			'Add a native input or textarea as descendant element.',
@@ -86,6 +89,7 @@ export default defineComponent<FormTextboxProps>(
 
 		const clearBtn = first('button.clear')
 		if (clearBtn) {
+			internals?.states.add('clearable')
 			on(clearBtn, 'click', () => {
 				host.clear()
 			})

--- a/examples/module/todo/module-todo.css
+++ b/examples/module/todo/module-todo.css
@@ -4,11 +4,11 @@ module-todo {
 	gap: var(--space-l);
 	container-type: inline-size;
 
-	&[filter="completed"] [data-container] li:not(:has(input:checked)) {
+	&:state(filter-completed) [data-container] li:not(:has(input:checked)) {
 		display: none;
 	}
 
-	&[filter="active"] [data-container] li:has(input:checked) {
+	&:state(filter-active) [data-container] li:has(input:checked) {
 		display: none;
 	}
 

--- a/examples/module/todo/module-todo.html
+++ b/examples/module/todo/module-todo.html
@@ -1,6 +1,6 @@
-<module-todo filter="all">
+<module-todo>
 	<form action="#">
-		<form-textbox clearable>
+		<form-textbox>
 			<label for="add-todo">What needs to be done?</label>
 			<div class="input">
 				<input id="add-todo" type="text" value="">

--- a/examples/module/todo/module-todo.md
+++ b/examples/module/todo/module-todo.md
@@ -1,6 +1,6 @@
 ### Module Todo
 
-A todo component that owns the data, manages the list DOM directly, and handles all interactions — adding, deleting, reordering (keyboard and drag), editing labels, and toggling completion.
+A todo component that owns the data, manages the list DOM directly, and handles all interactions — adding, deleting, reordering (keyboard and drag), editing labels, and toggling completion. Exposes the active filter as custom states (`:state(filter-active)`, `:state(filter-completed)`) for CSS-based item visibility.
 
 #### Preview
 
@@ -16,7 +16,7 @@ A todo component that owns the data, manages the list DOM directly, and handles 
 
 #### Reactive Properties
 
-None. This component orchestrates behavior by passing state and events between descendants.
+None. This component orchestrates behavior by passing state and events between descendants, and sets custom states (matched in CSS via `:state()`) based on the active filter.
 
 #### Descendant Elements
 

--- a/examples/module/todo/module-todo.spec.ts
+++ b/examples/module/todo/module-todo.spec.ts
@@ -11,6 +11,18 @@ function isHostChecked(element: Locator): Promise<boolean> {
 }
 
 /**
+ * Check whether a custom state (ElementInternals `states`) is set on the
+ * element, via the `:state()` pseudo-class. Evaluated in the browser because
+ * Playwright's own selector engine does not parse `:state()`.
+ */
+function hasState(element: Locator, state: string): Promise<boolean> {
+	return element.evaluate(
+		(el: Element, s: string) => el.matches(`:state(${s})`),
+		state,
+	)
+}
+
+/**
  * Test Suite: module-todo Component
  *
  * Comprehensive tests for the Le Truc module-todo component, which provides
@@ -386,15 +398,18 @@ test.describe('module-todo component', () => {
 
 			// Switch to "Active" filter
 			await filter.locator('label').filter({ hasText: 'Active' }).click()
-			await expect(todo).toHaveAttribute('filter', 'active')
+			await expect.poll(() => hasState(todo, 'filter-active')).toBe(true)
+			await expect.poll(() => hasState(todo, 'filter-completed')).toBe(false)
 
 			// Switch to "Completed" filter
 			await filter.locator('label').filter({ hasText: 'Completed' }).click()
-			await expect(todo).toHaveAttribute('filter', 'completed')
+			await expect.poll(() => hasState(todo, 'filter-completed')).toBe(true)
+			await expect.poll(() => hasState(todo, 'filter-active')).toBe(false)
 
 			// Switch back to "All"
 			await filter.locator('label').filter({ hasText: 'All' }).click()
-			await expect(todo).toHaveAttribute('filter', 'all')
+			await expect.poll(() => hasState(todo, 'filter-active')).toBe(false)
+			await expect.poll(() => hasState(todo, 'filter-completed')).toBe(false)
 		})
 	})
 

--- a/examples/module/todo/module-todo.ts
+++ b/examples/module/todo/module-todo.ts
@@ -1,6 +1,6 @@
 import {
-	bindAttribute,
 	bindProperty,
+	bindState,
 	bindText,
 	createList,
 	createMemo,
@@ -36,11 +36,13 @@ let idCounter = 0
  * A full-featured todo list with add, remove, complete, filter, and drag-and-drop reordering.
  * Use it as a reference example of a complete Le Truc application — keyboard accessible
  * controls and ARIA labelling should be considered when adapting it for production use.
+ * Exposes the active filter as custom states (`:state(filter-active)`, `:state(filter-completed)`)
+ * for CSS-based item visibility, so filter state cannot be spoofed by setting an attribute.
  * @demo {https://zeixcom.github.io/le-truc/examples.html#module-todo} Interactive preview and usage examples
  **/
 export default defineComponent(
 	'module-todo',
-	({ all, first, host, on, pass, watch }) => {
+	({ all, first, host, internals, on, pass, watch }) => {
 		const container = first(
 			'[data-container]',
 			'Add a container element for items.',
@@ -349,7 +351,14 @@ export default defineComponent(
 			'form-radiogroup',
 			'Add <form-radiogroup> component to filter todo items.',
 		)
-		watch(() => filter.value || 'all', bindAttribute(host, 'filter'))
+		watch(
+			() => (filter.value || 'all') === 'active',
+			bindState(internals, 'filter-active'),
+		)
+		watch(
+			() => (filter.value || 'all') === 'completed',
+			bindState(internals, 'filter-completed'),
+		)
 
 		watch(status, bindText(liveRegion))
 	},

--- a/server/effects/examples.ts
+++ b/server/effects/examples.ts
@@ -1,4 +1,5 @@
-import Markdoc from '@markdoc/markdoc'
+import { join } from 'node:path'
+import Markdoc, { type Node } from '@markdoc/markdoc'
 import { createEffect, match } from '@zeix/cause-effect'
 import { COMPONENTS_DIR, CONTENT_MARKER, EXAMPLES_DIR } from '../config'
 import {
@@ -18,6 +19,24 @@ const toPathMap = (files: FileInfo[]): Map<string, FileInfo> => {
 	return map
 }
 
+// Shared fragments referenced via Markdoc's built-in `{% partial file="..." /%}`
+// tag. Keyed by the exact `file` attribute value used in component docs.
+const PARTIALS: Record<string, string> = {
+	'form-associated.md': join(COMPONENTS_DIR, '_common', 'form-associated.md'),
+}
+
+// Not cached across calls: re-reading picks up edits to the fragment file
+// immediately under HMR/file-watch rebuilds, and the files are tiny.
+const loadPartials = async (): Promise<Record<string, Node>> => {
+	const entries = await Promise.all(
+		Object.entries(PARTIALS).map(async ([name, path]) => {
+			const content = await Bun.file(path).text()
+			return [name, Markdoc.parse(content)] as const
+		}),
+	)
+	return Object.fromEntries(entries)
+}
+
 const processExample = async (
 	componentName: string,
 	markdownContent: string,
@@ -32,14 +51,17 @@ const processExample = async (
 	// Parse with Markdoc
 	const ast = Markdoc.parse(processedContent)
 
+	const partials = await loadPartials()
+	const config = { ...markdocConfig, partials }
+
 	// Validate the document
-	const errors = Markdoc.validate(ast, markdocConfig)
+	const errors = Markdoc.validate(ast, config)
 	if (errors.length > 0) {
 		console.warn(`Markdoc validation errors for ${componentName}:`, errors)
 	}
 
 	// Transform the AST
-	const transformed = Markdoc.transform(ast, markdocConfig)
+	const transformed = Markdoc.transform(ast, config)
 
 	// Render to HTML
 	let htmlContent = Markdoc.renderers.html(transformed)

--- a/server/markdoc.config.ts
+++ b/server/markdoc.config.ts
@@ -3,6 +3,7 @@ import blogpost from './schema/blogpost.markdoc'
 import callout from './schema/callout.markdoc'
 import carousel from './schema/carousel.markdoc'
 import cemList from './schema/cem-list.markdoc'
+import collapsible from './schema/collapsible.markdoc'
 import demo from './schema/demo.markdoc'
 import fence from './schema/fence.markdoc'
 import heading from './schema/heading.markdoc'
@@ -25,6 +26,7 @@ export const markdocConfig = {
 		callout,
 		carousel,
 		'cem-list': cemList,
+		collapsible,
 		demo,
 		listnav,
 		sources,

--- a/server/schema/collapsible.markdoc.ts
+++ b/server/schema/collapsible.markdoc.ts
@@ -1,0 +1,25 @@
+import { type Config, type Node, type Schema, Tag } from '@markdoc/markdoc'
+import { requiredTitleAttribute, richChildren } from '../markdoc-constants'
+import { transformChildrenWithConfig } from '../markdoc-helpers'
+
+const collapsible: Schema = {
+	render: 'card-collapsible',
+	children: [...richChildren, 'table'],
+	attributes: {
+		title: requiredTitleAttribute,
+	},
+	transform(node: Node, config: Config) {
+		const { title } = node.attributes
+		const children = transformChildrenWithConfig(node.children ?? [], config)
+		return new Tag('card-collapsible', {}, [
+			new Tag('details', {}, [
+				new Tag('summary', {}, [
+					new Tag('span', { class: 'description' }, [title]),
+				]),
+				new Tag('div', { class: 'content' }, children),
+			]),
+		])
+	},
+}
+
+export default collapsible

--- a/server/tests/effects/examples.test.ts
+++ b/server/tests/effects/examples.test.ts
@@ -30,4 +30,17 @@ describe('processExample', () => {
 		expect(result).toContain('<div class="preview">')
 		expect(result).not.toContain('preview-html=')
 	})
+
+	test('resolves the shared form-associated.md partial into a details/summary block', async () => {
+		const markdown = `### Demo\n\n{{ content }}\n\n{% partial file="form-associated.md" /%}`
+		const componentHtml = `<form-textbox></form-textbox>`
+
+		const result = await processExample('form-textbox', markdown, componentHtml)
+
+		expect(result).toContain('<card-collapsible>')
+		expect(result).toContain('<details>')
+		expect(result).toContain('class="description">Participates in HTML forms')
+		expect(result).toContain('checkValidity')
+		expect(result).toContain('willValidate')
+	})
 })

--- a/server/tests/schema/collapsible.test.ts
+++ b/server/tests/schema/collapsible.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit Tests for schema/collapsible.markdoc.ts — Collapsible Schema
+ *
+ * Tests for the collapsible Markdoc schema transformation: progressive
+ * disclosure rendered via the `<card-collapsible>` example component, which
+ * wraps a native `<details>`/`<summary>` element.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import Markdoc, { Node, Tag } from '@markdoc/markdoc'
+import collapsible from '../../schema/collapsible.markdoc'
+
+/* === Helpers === */
+
+const config = { tags: { collapsible } }
+
+function transformCollapsible(
+	attrs: Record<string, unknown>,
+	children: Node[] = [],
+): Tag {
+	const node = new Node('tag', attrs, children, 'collapsible')
+	return Markdoc.transform(node, config) as Tag
+}
+
+/* === Collapsible schema === */
+
+describe('collapsible schema', () => {
+	test('renders "card-collapsible" element', () => {
+		const result = transformCollapsible({ title: 'More info' })
+		expect(result).toBeInstanceOf(Tag)
+		expect(result.name).toBe('card-collapsible')
+	})
+
+	test('renders a native details/summary structure inside card-collapsible', () => {
+		const result = transformCollapsible({ title: 'More info' })
+		const details = result.children[0] as Tag
+		expect(details).toBeInstanceOf(Tag)
+		expect(details.name).toBe('details')
+
+		const summary = details.children[0] as Tag
+		expect(summary).toBeInstanceOf(Tag)
+		expect(summary.name).toBe('summary')
+	})
+
+	test('renders the title inside a summary > span.description', () => {
+		const result = transformCollapsible({ title: 'More info' })
+		const details = result.children[0] as Tag
+		const summary = details.children[0] as Tag
+		const description = summary.children[0] as Tag
+		expect(description).toBeInstanceOf(Tag)
+		expect(description.name).toBe('span')
+		expect(description.attributes.class).toBe('description')
+		expect(description.children[0]).toBe('More info')
+	})
+
+	test('renders transformed children inside a div.content sibling of summary', () => {
+		const child = new Node('paragraph', {}, [
+			new Node('text', { content: 'Hidden content' }),
+		])
+		const result = transformCollapsible({ title: 'More info' }, [child])
+		const details = result.children[0] as Tag
+		const content = details.children[1] as Tag
+		expect(content).toBeInstanceOf(Tag)
+		expect(content.name).toBe('div')
+		expect(content.attributes.class).toBe('content')
+		expect(content.children.length).toBeGreaterThan(0)
+		const paragraph = content.children[0] as Tag
+		expect(paragraph).toBeInstanceOf(Tag)
+		expect(paragraph.name).toBe('p')
+	})
+
+	test('requires a title attribute', () => {
+		const node = new Node('tag', {}, [], 'collapsible')
+		const errors = Markdoc.validate(node, config)
+		expect(errors.length).toBeGreaterThan(0)
+	})
+
+	test('allows a table as a direct child without validation errors', () => {
+		const table = new Node('table', {}, [], 'table')
+		const node = new Node('tag', { title: 'More info' }, [table], 'collapsible')
+		const errors = Markdoc.validate(node, config)
+		expect(errors).toEqual([])
+	})
+})


### PR DESCRIPTION
## Summary

- Fills a documentation gap left by the 2.3.1 upgrade: 8 form-associated example components (`form-colorgraph`, `form-checkbox`, `form-combobox`, `form-inplace-edit`, `form-listbox`, `form-radiogroup`, `form-spinbutton`, `form-textbox`) were missing docs for the properties/methods `formAssociated()`/`formAssociatedCheckbox()` install (`disabled`, `form`, `labels`, `name`, `validationMessage`, `validity`, `willValidate`, `checkValidity()`, `reportValidity()`, `setCustomValidity()`), plus a few other undocumented/mis-categorized attributes (`module-todo`'s filter, `form-textbox`'s clearable/disabled/name, `basic-gauge`'s thresholds).
- Adds Markdoc pipeline support for shared content: a `{% partial file="..." /%}` mechanism (Markdoc's built-in tag, newly wired up) so the repeated form-control contract block lives once in `examples/_common/form-associated.md` instead of being copy-pasted 8 times, and a new `{% collapsible %}` tag that renders it as progressive disclosure via the existing `<card-collapsible>` component instead of a wall of always-visible tables.
- Refactors two attributes that existed only as CSS styling hooks (`module-todo`'s `filter`, `form-textbox`'s `clearable`) into `ElementInternals` custom states (`:state(...)`), since a plain attribute is spoofable input while a state is component-owned.

## Test plan

- [x] `bun test src/tests` (355 pass)
- [x] `bun test server/tests` (678 pass)
- [x] `bunx biome check` clean on `src/`, `examples/`, `server/`
- [x] `bun run build:cem` — manifest reflects new/removed attributes correctly
- [x] Full `bun ./server/build.ts` — all example pages build without Markdoc validation errors
- [x] `node node_modules/.bin/playwright test examples/module/todo examples/form/textbox` (76/76 pass), including updated `:state()` assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)