### PR TITLE
feat(server): improve generated API docs

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -10,6 +10,7 @@ const ROOT = join(import.meta.dir, '..')
 
 // Path constants
 const SRC_DIR = join(ROOT, 'src')
+const ADR_DIR = join(ROOT, 'adr')
 
 const COMPONENTS_DIR = join(ROOT, 'examples')
 const CSS_FILE = join(ROOT, 'examples/main.css')
@@ -111,6 +112,7 @@ const COMPRESSIBLE_TYPES = [
 ] as const
 
 export {
+	ADR_DIR,
 	API_DIR,
 	ASSETS_DIR,
 	BASE_URL,

--- a/server/effects/api-pages.ts
+++ b/server/effects/api-pages.ts
@@ -4,10 +4,15 @@ import Markdoc, {
 	Tag,
 } from '@markdoc/markdoc'
 import { createEffect, match } from '@zeix/cause-effect'
-import { API_DIR, OUTPUT_DIR } from '../config'
+import { ADR_DIR, API_DIR, OUTPUT_DIR } from '../config'
 import { apiMarkdown, type FileInfo } from '../file-signals'
 import { highlightCodeBlocks } from '../html-shaping'
-import { getFilePath, getRelativePath, writeFileSafe } from '../io'
+import {
+	getDirectoryEntries,
+	getFilePath,
+	getRelativePath,
+	writeFileSafe,
+} from '../io'
 import markdocConfig from '../markdoc.config'
 
 /* === Internal Functions === */
@@ -49,6 +54,58 @@ const linkExternalDefinedIn = (content: string): string =>
 			return `Defined in: [${path}.ts](https://github.com/${repo}/blob/main/${path}.ts)`
 		},
 	)
+
+/**
+ * Matches an "ADR NNNN" mention anywhere in prose, not anchored to a specific
+ * surrounding phrase or trailing punctuation — the codebase's actual JSDoc
+ * convention varies ("See ADR 0011.", "see ADR 0007)", "See ADR 0017 for
+ * full rationale..."). Case-insensitive as a safety margin; the acronym is
+ * written "ADR" everywhere observed.
+ */
+const ADR_REFERENCE = /\bADR (\d{4})\b/gi
+
+/**
+ * List `adr/` and map ADR number to its filename slug (without extension),
+ * so inline "See ADR NNNN." prose can be turned into a real link. Not cached:
+ * re-reading is cheap (a couple dozen tiny files) and picks up newly recorded
+ * ADRs immediately under HMR/file-watch rebuilds, same reasoning as
+ * `loadPartials()` in effects/examples.ts.
+ */
+const loadAdrSlugMap = async (): Promise<Record<string, string>> => {
+	const entries = await getDirectoryEntries(ADR_DIR)
+	const map: Record<string, string> = {}
+	for (const entry of entries) {
+		if (!entry.isFile()) continue
+		const match = entry.name.match(/^(\d{4})-.+\.md$/)
+		if (match) map[match[1]!] = entry.name.replace(/\.md$/, '')
+	}
+	return map
+}
+
+/**
+ * Rewrite inline "ADR NNNN" mentions (plain prose in JSDoc, TypeDoc emits
+ * them unlinked) into a link to the ADR file on GitHub — this pipeline
+ * doesn't ship `adr/` into `docs/`, so link out rather than to a local path,
+ * same reasoning `linkExternalDefinedIn` uses for `node_modules` dependency
+ * source links. Only the "ADR NNNN" span itself is replaced, leaving
+ * surrounding punctuation/phrasing untouched, so this reads correctly
+ * whether the mention is "See ADR 0011.", mid-sentence ("see ADR 0007)"),
+ * or followed by more prose ("See ADR 0017 for full rationale"). An ADR
+ * number with no matching file (typo, renumbered) is left as plain text
+ * with a warning rather than thrown.
+ */
+const linkAdrReferences = (
+	content: string,
+	adrSlugs: Record<string, string>,
+): string =>
+	content.replace(ADR_REFERENCE, (match, number: string) => {
+		const slug = adrSlugs[number]
+		if (!slug) {
+			console.warn(`No ADR file found for referenced ADR ${number}`)
+			return match
+		}
+		return `[ADR ${number}](https://github.com/zeixcom/le-truc/blob/main/adr/${slug}.md)`
+	})
 
 /** Recursively read the first text content of a renderable node */
 const firstTextContent = (node: RenderableTreeNode): string => {
@@ -302,6 +359,318 @@ const convertParameterSectionsToTables = (
 }
 
 /**
+ * Wrap the content following a "Deprecated" heading in a loud `caution`
+ * `card-callout` with a title (same shape server/schema/callout.markdoc.ts
+ * produces), dropping the original heading since the callout carries that
+ * meaning now — this is the case that should actually catch a reader's eye.
+ *
+ * "Since" deliberately does NOT get this treatment: every `card-callout`
+ * class (including `.note`) renders as a full padded/bordered/icon box in
+ * `examples/card/callout/card-callout.css` — there's no quiet variant — and
+ * "Since" appears on nearly every symbol (multiple times on anything
+ * overloaded, e.g. 6× on createSignal.html), so wrapping it produced a wall
+ * of colored boxes for a single version string. Left as plain text.
+ */
+const wrapDeprecatedCallout = (
+	root: RenderableTreeNodes,
+): RenderableTreeNodes => {
+	if (!Tag.isTag(root)) return root
+
+	const children: RenderableTreeNode[] = []
+	const siblings = root.children
+	let i = 0
+	while (i < siblings.length) {
+		const node = siblings[i]!
+		const level = headingTagLevel(node)
+		const text = level !== null ? headingTagText(node) : null
+
+		if (text === 'Deprecated') {
+			const body: RenderableTreeNode[] = []
+			let j = i + 1
+			while (j < siblings.length && headingTagLevel(siblings[j]!) === null) {
+				body.push(siblings[j]!)
+				j++
+			}
+			if (body.length === 0) {
+				children.push(node)
+				i++
+				continue
+			}
+			children.push(
+				new Tag('card-callout', { class: 'caution' }, [
+					new Tag('p', {}, [new Tag('strong', {}, ['Deprecated'])]),
+					...body,
+				]),
+			)
+			i = j
+			continue
+		}
+		children.push(node)
+		i++
+	}
+	return new Tag(root.name, root.attributes, children)
+}
+
+const CALL_SIGNATURE_LABEL = 'Call Signature'
+
+/**
+ * Collect the body of a single "Call Signature" section: everything after
+ * the heading up to (not including) the next "Call Signature" heading (next
+ * overload) or a heading whose text isn't a recognized sub-section label (a
+ * new symbol/section entirely, not part of this overload). Heading *level*
+ * isn't a reliable boundary here — TypeDoc's h6-depth-ceiling clamping can
+ * put a Call Signature's own children (Returns, Inherited from, ...) at a
+ * shallower level than the Call Signature heading itself (see
+ * `composedPath()` in ContextRequestEvent.md, an inherited DOM overload).
+ */
+const collectCallSignatureBody = (
+	siblings: RenderableTreeNode[],
+	startIndex: number,
+): { body: RenderableTreeNode[]; nextIndex: number } => {
+	const body: RenderableTreeNode[] = []
+	let i = startIndex
+	while (i < siblings.length) {
+		const node = siblings[i]!
+		const level = headingTagLevel(node)
+		if (level !== null) {
+			const text = headingTagText(node)
+			if (text === CALL_SIGNATURE_LABEL) break
+			if (!PARAM_SECTION_STOP_LABELS.has(text)) break
+		}
+		body.push(node)
+		i++
+	}
+	return { body, nextIndex: i }
+}
+
+/**
+ * Tab structure identical to what server/schema/tabgroup.markdoc.ts produces.
+ * `groupIndex` disambiguates ids across multiple overloaded methods on the
+ * same page (e.g. ContextRequestEvent.md has overloads on both
+ * composedPath() and preventDefault()) — without it every tab group would
+ * emit the same "panel_overload-1"/"panel_overload-2" ids, which is invalid
+ * HTML and breaks aria-controls/aria-labelledby wiring.
+ */
+const buildOverloadTabGroup = (
+	groups: RenderableTreeNode[][],
+	groupIndex: number,
+): Tag => {
+	const tabs = groups.map((body, index) => ({
+		label: `Overload ${index + 1}`,
+		id: `panel_overload-${groupIndex}-${index + 1}`,
+		body,
+	}))
+
+	const tablist = new Tag(
+		'div',
+		{ role: 'tablist' },
+		tabs.map((tab, index) => {
+			const isSelected = index === 0
+			const triggerId = tab.id.replace('panel_', 'trigger_')
+			return new Tag(
+				'button',
+				{
+					role: 'tab',
+					id: triggerId,
+					'aria-controls': tab.id,
+					'aria-selected': String(isSelected),
+					tabindex: isSelected ? '0' : '-1',
+				},
+				[tab.label],
+			)
+		}),
+	)
+
+	const tabpanels = tabs.map((tab, index) => {
+		const isSelected = index === 0
+		const triggerId = tab.id.replace('panel_', 'trigger_')
+		const attributes: Record<string, string> = {
+			role: 'tabpanel',
+			id: tab.id,
+			'aria-labelledby': triggerId,
+		}
+		if (!isSelected) attributes.hidden = ''
+		return new Tag('div', attributes, [new Tag(undefined, {}, tab.body)])
+	})
+
+	return new Tag('module-tabgroup', {}, [tablist, ...tabpanels])
+}
+
+/**
+ * TypeDoc emits one "Call Signature" heading per overload, all as siblings
+ * under the same symbol heading, with no label distinguishing one overload
+ * from another (e.g. createElementsMemo()'s two generic signatures, or
+ * composedPath()'s inherited DOM overloads). Replace ≥2 consecutive Call
+ * Signature groups with a tab group labeled "Overload 1", "Overload 2", etc.
+ * A lone Call Signature (no sibling) is left untouched.
+ */
+const mergeOverloadCallSignatures = (
+	root: RenderableTreeNodes,
+): RenderableTreeNodes => {
+	if (!Tag.isTag(root)) return root
+
+	const children: RenderableTreeNode[] = []
+	const siblings = root.children
+	let groupCount = 0
+	let i = 0
+	while (i < siblings.length) {
+		const node = siblings[i]!
+		const level = headingTagLevel(node)
+		const text = level !== null ? headingTagText(node) : null
+
+		if (text === CALL_SIGNATURE_LABEL) {
+			const groups: RenderableTreeNode[][] = []
+			let j = i
+			while (
+				j < siblings.length &&
+				headingTagLevel(siblings[j]!) !== null &&
+				headingTagText(siblings[j]!) === CALL_SIGNATURE_LABEL
+			) {
+				const { body, nextIndex } = collectCallSignatureBody(siblings, j + 1)
+				groups.push(body)
+				j = nextIndex
+			}
+
+			if (groups.length < 2) {
+				children.push(node, ...groups[0]!)
+				i = j
+				continue
+			}
+
+			groupCount++
+			children.push(buildOverloadTabGroup(groups, groupCount))
+			i = j
+			continue
+		}
+
+		children.push(node)
+		i++
+	}
+	return new Tag(root.name, root.attributes, children)
+}
+
+type MemberEntry = {
+	heading: RenderableTreeNode
+	body: RenderableTreeNode[]
+}
+
+/**
+ * Collect "member heading + body" entries directly under a Properties/Methods
+ * section heading, one level deeper. Unlike `extractNamedRows`, member bodies
+ * can contain their own sub-headings (Inherited from, Deprecated, Call
+ * Signature, ...) at deeper levels — only a heading at exactly
+ * `sectionLevel + 1` starts a new member; anything deeper is body content,
+ * and anything at `sectionLevel` or shallower ends the section. Properties/
+ * Methods headings sit at a shallow level in practice (never near the h6
+ * ceiling `extractNamedRows` has to guard against), so this simpler
+ * level-only check is sufficient here.
+ */
+const extractMemberEntries = (
+	siblings: RenderableTreeNode[],
+	startIndex: number,
+	sectionLevel: number,
+): { entries: MemberEntry[]; nextIndex: number } | null => {
+	const entries: MemberEntry[] = []
+	let current: MemberEntry | null = null
+	let i = startIndex
+	while (i < siblings.length) {
+		const node = siblings[i]!
+		const level = headingTagLevel(node)
+		if (level !== null && level <= sectionLevel) break
+		if (level === sectionLevel + 1) {
+			current = { heading: node, body: [] }
+			entries.push(current)
+			i++
+			continue
+		}
+		if (!current) return null
+		current.body.push(node)
+		i++
+	}
+	if (entries.length === 0) return null
+	return { entries, nextIndex: i }
+}
+
+/** Recursively search a node list for a heading with the given exact text. */
+const containsHeadingText = (
+	nodes: RenderableTreeNode[],
+	text: string,
+): boolean =>
+	nodes.some(node => {
+		if (!Tag.isTag(node)) return false
+		if (headingTagLevel(node) !== null) return headingTagText(node) === text
+		return containsHeadingText(node.children, text)
+	})
+
+/** Collapsible structure identical to server/schema/collapsible.markdoc.ts. */
+const buildInheritedMembersCollapsible = (entries: MemberEntry[]): Tag => {
+	const content = entries.flatMap(entry => [entry.heading, ...entry.body])
+	return new Tag('card-collapsible', {}, [
+		new Tag('details', {}, [
+			new Tag('summary', {}, [
+				new Tag('span', { class: 'description' }, [
+					`Inherited members (${entries.length})`,
+				]),
+			]),
+			new Tag('div', { class: 'content' }, content),
+		]),
+	])
+}
+
+const MEMBER_SECTION_LABELS = new Set(['Properties', 'Methods'])
+
+/**
+ * Classes/interfaces extending a large native type are dominated by inherited
+ * boilerplate (e.g. FormAssociatedElement.md: 314 inherited vs. 255 own
+ * members). Within each Properties/Methods section, pull out any member
+ * whose body contains a descendant "Inherited from" heading — recursively,
+ * so members already re-nested by `mergeOverloadCallSignatures` (which runs
+ * first) are still found — and group them into a single collapsible appended
+ * after the own members, which stay inline in original order.
+ */
+const collapseInheritedMembers = (
+	root: RenderableTreeNodes,
+): RenderableTreeNodes => {
+	if (!Tag.isTag(root)) return root
+
+	const children: RenderableTreeNode[] = []
+	const siblings = root.children
+	let i = 0
+	while (i < siblings.length) {
+		const node = siblings[i]!
+		const level = headingTagLevel(node)
+		const text = level !== null ? headingTagText(node) : null
+
+		if (level !== null && MEMBER_SECTION_LABELS.has(text!)) {
+			const extracted = extractMemberEntries(siblings, i + 1, level)
+			if (extracted) {
+				const ownEntries: MemberEntry[] = []
+				const inheritedEntries: MemberEntry[] = []
+				for (const entry of extracted.entries) {
+					if (containsHeadingText(entry.body, 'Inherited from')) {
+						inheritedEntries.push(entry)
+					} else {
+						ownEntries.push(entry)
+					}
+				}
+				children.push(node)
+				for (const entry of ownEntries)
+					children.push(entry.heading, ...entry.body)
+				if (inheritedEntries.length > 0) {
+					children.push(buildInheritedMembersCollapsible(inheritedEntries))
+				}
+				i = extracted.nextIndex
+				continue
+			}
+		}
+
+		children.push(node)
+		i++
+	}
+	return new Tag(root.name, root.attributes, children)
+}
+
+/**
  * Headings built by createAccessibleHeading() carry generic labels ("Parameters",
  * "Returns", "Inherited from", "Call Signature") that repeat across every constructor,
  * property, and method on a generated API page, producing duplicate ids. Walk the page
@@ -408,7 +777,10 @@ const makeHeadingIdsUnique = (
  * Fragments are suitable for injection by module-lazyload (no doctype/head/body).
  * The server applies the full api.html layout on-the-fly for direct navigation.
  */
-const processApiFile = async (file: FileInfo): Promise<void> => {
+const processApiFile = async (
+	file: FileInfo,
+	adrSlugs: Record<string, string>,
+): Promise<void> => {
 	const relativePath = getRelativePath(API_DIR, file.path)
 	if (!relativePath) return
 
@@ -422,8 +794,12 @@ const processApiFile = async (file: FileInfo): Promise<void> => {
 		return
 	}
 
-	// Strip TypeDoc navigation breadcrumbs and link external "Defined in:" paths
-	const cleanContent = linkExternalDefinedIn(stripBreadcrumbs(file.content))
+	// Strip TypeDoc navigation breadcrumbs, link external "Defined in:" paths
+	// and inline "See ADR NNNN." references
+	const cleanContent = linkAdrReferences(
+		linkExternalDefinedIn(stripBreadcrumbs(file.content)),
+		adrSlugs,
+	)
 
 	// Parse with Markdoc
 	const ast = Markdoc.parse(cleanContent)
@@ -432,9 +808,19 @@ const processApiFile = async (file: FileInfo): Promise<void> => {
 		console.warn(`Markdoc validation warnings for ${relativePath}:`, errors)
 	}
 
+	// Passes that scan the flat top-level tree must run before the passes
+	// that nest content (tabs, collapsibles) — nesting passes only need to
+	// run in an order where each still finds what it depends on; see the
+	// doc comments on collectCallSignatureBody/collapseInheritedMembers.
 	const transformed = makeHeadingIdsUnique(
-		convertParameterSectionsToTables(
-			mergeDefinedInIntoBlockquote(Markdoc.transform(ast, markdocConfig)),
+		collapseInheritedMembers(
+			mergeOverloadCallSignatures(
+				wrapDeprecatedCallout(
+					convertParameterSectionsToTables(
+						mergeDefinedInIntoBlockquote(Markdoc.transform(ast, markdocConfig)),
+					),
+				),
+			),
 		),
 	)
 	let htmlContent = Markdoc.renderers.html(transformed)
@@ -473,11 +859,16 @@ const processApiFile = async (file: FileInfo): Promise<void> => {
 
 // Exported for testing
 export {
+	collapseInheritedMembers,
 	convertParameterSectionsToTables,
+	linkAdrReferences,
 	linkExternalDefinedIn,
+	loadAdrSlugMap,
 	makeHeadingIdsUnique,
 	mergeDefinedInIntoBlockquote,
+	mergeOverloadCallSignatures,
 	stripBreadcrumbs,
+	wrapDeprecatedCallout,
 }
 
 export const apiPagesEffect = (onRebuild?: () => void) => {
@@ -492,10 +883,11 @@ export const apiPagesEffect = (onRebuild?: () => void) => {
 				try {
 					console.log('📖 Generating API page fragments...')
 
+					const adrSlugs = await loadAdrSlugMap()
 					let count = 0
 					const processPromises = apiFiles.map(async (file: FileInfo) => {
 						try {
-							await processApiFile(file)
+							await processApiFile(file, adrSlugs)
 							count++
 						} catch (error) {
 							console.error(`Failed to process API file ${file.path}:`, error)

--- a/server/tests/effects/api-pages.test.ts
+++ b/server/tests/effects/api-pages.test.ts
@@ -8,11 +8,16 @@
 import { describe, expect, test } from 'bun:test'
 import Markdoc from '@markdoc/markdoc'
 import {
+	collapseInheritedMembers,
 	convertParameterSectionsToTables,
+	linkAdrReferences,
 	linkExternalDefinedIn,
+	loadAdrSlugMap,
 	makeHeadingIdsUnique,
 	mergeDefinedInIntoBlockquote,
+	mergeOverloadCallSignatures,
 	stripBreadcrumbs,
+	wrapDeprecatedCallout,
 } from '../../effects/api-pages'
 import { highlightCodeBlocks } from '../../html-shaping'
 import markdocConfig from '../../markdoc.config'
@@ -36,6 +41,30 @@ const renderApiUniqueIds = (markdown: string): string => {
 const renderApiTables = (markdown: string): string => {
 	const ast = Markdoc.parse(markdown)
 	const transformed = convertParameterSectionsToTables(
+		Markdoc.transform(ast, markdocConfig),
+	)
+	return Markdoc.renderers.html(transformed)
+}
+
+const renderApiCallouts = (markdown: string): string => {
+	const ast = Markdoc.parse(markdown)
+	const transformed = wrapDeprecatedCallout(
+		Markdoc.transform(ast, markdocConfig),
+	)
+	return Markdoc.renderers.html(transformed)
+}
+
+const renderApiOverloads = (markdown: string): string => {
+	const ast = Markdoc.parse(markdown)
+	const transformed = mergeOverloadCallSignatures(
+		Markdoc.transform(ast, markdocConfig),
+	)
+	return Markdoc.renderers.html(transformed)
+}
+
+const renderApiInheritedMembers = (markdown: string): string => {
+	const ast = Markdoc.parse(markdown)
+	const transformed = collapseInheritedMembers(
 		Markdoc.transform(ast, markdocConfig),
 	)
 	return Markdoc.renderers.html(transformed)
@@ -513,6 +542,364 @@ describe('makeHeadingIdsUnique', () => {
 			'<a href="#properties-bubbles"><code>bubbles</code></a>',
 		)
 		expect(html).not.toContain('href="#bubbles"')
+	})
+})
+
+/* === wrapDeprecatedCallout Tests === */
+
+describe('wrapDeprecatedCallout', () => {
+	test('wraps Deprecated content in a caution callout with a title', () => {
+		const html = renderApiCallouts(`##### initEvent()
+
+###### Deprecated
+
+[MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/initEvent)`)
+
+		expect(html).toContain('card-callout')
+		expect(html).toContain('caution')
+		expect(html).toContain('<strong>Deprecated</strong>')
+		expect(html).toContain('MDN Reference')
+		expect(html).not.toMatch(/<h6[^>]*>.*Deprecated.*<\/h6>/)
+	})
+
+	test('leaves Since untouched — card-callout has no quiet variant, so this stays plain text', () => {
+		const html = renderApiCallouts(`##### Since
+
+0.16.0`)
+
+		expect(html).not.toContain('card-callout')
+		expect(html).toMatch(/<h5[^>]*>.*Since.*<\/h5>/)
+		expect(html).toContain('0.16.0')
+	})
+
+	test('leaves a Deprecated heading with no body untouched', () => {
+		const html = renderApiCallouts(`##### Deprecated
+
+##### Throws
+
+If malformed`)
+
+		expect(html).not.toContain('card-callout')
+		expect(html).toMatch(/<h5[^>]*>.*Deprecated.*<\/h5>/)
+	})
+
+	test('leaves unrelated headings untouched', () => {
+		const html = renderApiCallouts(`##### Returns
+
+\`void\``)
+
+		expect(html).not.toContain('card-callout')
+	})
+})
+
+/* === mergeOverloadCallSignatures Tests === */
+
+describe('mergeOverloadCallSignatures', () => {
+	test('merges two Call Signature sections into a tab group', () => {
+		const html = renderApiOverloads(`### Function: createElementsMemo()
+
+#### Call Signature
+
+> **createElementsMemo**\\<\`S\`\\>(\`parent\`, \`selector\`)
+
+##### Returns
+
+\`Memo\`
+
+#### Call Signature
+
+> **createElementsMemo**\\<\`E\`\\>(\`parent\`, \`selector\`)
+
+##### Returns
+
+\`Memo\``)
+
+		expect(html).toContain('module-tabgroup')
+		expect(html).toContain('role="tablist"')
+		expect(html).toContain('Overload 1')
+		expect(html).toContain('Overload 2')
+		expect(html.match(/role="tabpanel"/g)).toHaveLength(2)
+		expect(html).not.toContain('Call Signature')
+	})
+
+	test('first tab is visible, subsequent tabs are hidden', () => {
+		const html = renderApiOverloads(`#### Call Signature
+
+Signature one
+
+#### Call Signature
+
+Signature two`)
+
+		const panels = [...html.matchAll(/<div role="tabpanel"[^>]*>/g)]
+		expect(panels).toHaveLength(2)
+		expect(panels[0]![0]).not.toContain('hidden')
+		expect(panels[1]![0]).toContain('hidden')
+	})
+
+	test('leaves a lone Call Signature (no overload) untouched', () => {
+		const html = renderApiOverloads(`### Function: foo()
+
+#### Call Signature
+
+> **foo**(): \`void\`
+
+##### Returns
+
+\`void\``)
+
+		expect(html).not.toContain('module-tabgroup')
+		expect(html).toContain('Call Signature')
+	})
+
+	test('handles an overload whose children clamp to a shallower level than the heading itself', () => {
+		// Mirrors composedPath() in ContextRequestEvent.md: an inherited DOM
+		// overload where "Call Signature" sits at h6 but its own "Returns"/
+		// "Inherited from" children render at h5 — shallower, not deeper.
+		const html = renderApiOverloads(`##### composedPath()
+
+###### Call Signature
+
+> **composedPath**(): \`EventTarget\`[]
+
+##### Returns
+
+\`EventTarget\`[]
+
+##### Inherited from
+
+\`Event.composedPath\`
+
+###### Call Signature
+
+> **composedPath**(): [\`EventTarget\`?]
+
+##### Returns
+
+[\`EventTarget\`?]
+
+##### Inherited from
+
+\`Event.composedPath\``)
+
+		expect(html).toContain('module-tabgroup')
+		expect(html.match(/role="tabpanel"/g)).toHaveLength(2)
+		expect(html).toContain('Inherited from')
+	})
+
+	test('gives distinct ids to tab groups from different overloaded methods on the same page', () => {
+		// A page with two separately-overloaded methods (e.g. ContextRequestEvent.md's
+		// composedPath() and preventDefault()) must not emit duplicate
+		// "panel_overload-1"/"panel_overload-2" ids across the two tab groups.
+		const html = renderApiOverloads(`##### composedPath()
+
+###### Call Signature
+
+Signature one
+
+###### Call Signature
+
+Signature two
+
+##### preventDefault()
+
+###### Call Signature
+
+Signature one
+
+###### Call Signature
+
+Signature two`)
+
+		const ids = [...html.matchAll(/id="([^"]+)"/g)].map(m => m[1])
+		expect(new Set(ids).size).toBe(ids.length)
+	})
+})
+
+/* === collapseInheritedMembers Tests === */
+
+describe('collapseInheritedMembers', () => {
+	test('splits inherited members into a collapsible, keeps own members inline', () => {
+		const html = renderApiInheritedMembers(`#### Properties
+
+##### context
+
+\`string\`
+
+The context key.
+
+##### bubbles
+
+\`boolean\`
+
+###### Inherited from
+
+\`Event.bubbles\``)
+
+		expect(html).toContain('card-collapsible')
+		expect(html).toContain('Inherited members (1)')
+		expect(html).toContain('The context key.')
+		// own member renders before the collapsible, inherited member inside it
+		const contextIndex = html.indexOf('context')
+		const collapsibleIndex = html.indexOf('card-collapsible')
+		expect(contextIndex).toBeLessThan(collapsibleIndex)
+		expect(html).toContain('bubbles')
+	})
+
+	test('leaves a section with no inherited members untouched', () => {
+		const html = renderApiInheritedMembers(`#### Properties
+
+##### context
+
+\`string\``)
+
+		expect(html).not.toContain('card-collapsible')
+	})
+
+	test('leaves sections other than Properties/Methods untouched', () => {
+		const html = renderApiInheritedMembers(`#### Extends
+
+- \`Error\``)
+
+		expect(html).not.toContain('card-collapsible')
+	})
+
+	test('finds inherited members nested inside an already-merged overload tab group', () => {
+		const merged = mergeOverloadCallSignatures(
+			Markdoc.transform(
+				Markdoc.parse(`#### Methods
+
+##### composedPath()
+
+###### Call Signature
+
+Signature one
+
+##### Inherited from
+
+\`Event.composedPath\`
+
+###### Call Signature
+
+Signature two
+
+##### Inherited from
+
+\`Event.composedPath\`
+
+##### own()
+
+Not inherited.`),
+				markdocConfig,
+			),
+		)
+		const transformed = collapseInheritedMembers(merged)
+		const html = Markdoc.renderers.html(transformed)
+
+		expect(html).toContain('card-collapsible')
+		expect(html).toContain('Inherited members (1)')
+		expect(html).toContain('module-tabgroup')
+		expect(html).toContain('Not inherited.')
+	})
+})
+
+/* === linkAdrReferences Tests === */
+
+describe('linkAdrReferences', () => {
+	test('links a known ADR reference', () => {
+		const content = 'isn’t Slot-backed. See ADR 0011.'
+		const result = linkAdrReferences(content, {
+			'0011': '0011-throw-on-pass-binding-failure',
+		})
+
+		expect(result).toBe(
+			'isn’t Slot-backed. See [ADR 0011](https://github.com/zeixcom/le-truc/blob/main/adr/0011-throw-on-pass-binding-failure.md).',
+		)
+	})
+
+	test('leaves an unknown ADR number untouched and warns', () => {
+		const warn = console.warn
+		let warned = false
+		console.warn = () => {
+			warned = true
+		}
+		try {
+			const content = 'See ADR 9999.'
+			expect(linkAdrReferences(content, {})).toBe(content)
+			expect(warned).toBe(true)
+		} finally {
+			console.warn = warn
+		}
+	})
+
+	test('links multiple references in the same document', () => {
+		const content = 'See ADR 0001. Elsewhere, See ADR 0002.'
+		const result = linkAdrReferences(content, {
+			'0001': '0001-foo',
+			'0002': '0002-bar',
+		})
+
+		expect(result).toContain(
+			'[ADR 0001](https://github.com/zeixcom/le-truc/blob/main/adr/0001-foo.md)',
+		)
+		expect(result).toContain(
+			'[ADR 0002](https://github.com/zeixcom/le-truc/blob/main/adr/0002-bar.md)',
+		)
+	})
+
+	test('leaves content without ADR references untouched', () => {
+		const content = 'No references here.'
+		expect(linkAdrReferences(content, {})).toBe(content)
+	})
+
+	test('links a lowercase "see" mention mid-sentence, inside parens', () => {
+		const content =
+			'activated yet — see ADR 0007). The request is therefore re-dispatched'
+		const result = linkAdrReferences(content, { '0007': '0007-foo' })
+
+		expect(result).toBe(
+			'activated yet — see [ADR 0007](https://github.com/zeixcom/le-truc/blob/main/adr/0007-foo.md)). The request is therefore re-dispatched',
+		)
+	})
+
+	test('links a reference with no trailing period, followed by more prose', () => {
+		const content = 'See ADR 0017 for full rationale (SSR adoption).'
+		const result = linkAdrReferences(content, { '0017': '0017-foo' })
+
+		expect(result).toBe(
+			'See [ADR 0017](https://github.com/zeixcom/le-truc/blob/main/adr/0017-foo.md) for full rationale (SSR adoption).',
+		)
+	})
+
+	test('links a reference followed by a closing paren and period, both left untouched', () => {
+		const content = 'see ADR 0003).'
+		const result = linkAdrReferences(content, { '0003': '0003-foo' })
+
+		expect(result).toBe(
+			'see [ADR 0003](https://github.com/zeixcom/le-truc/blob/main/adr/0003-foo.md)).',
+		)
+	})
+})
+
+/* === loadAdrSlugMap Tests === */
+
+describe('loadAdrSlugMap', () => {
+	test('maps known ADR numbers to their filename slug', async () => {
+		const map = await loadAdrSlugMap()
+
+		expect(map['0001']).toBe(
+			'0001-use-cause-effect-as-reactive-primitive-layer',
+		)
+		expect(Object.keys(map).length).toBeGreaterThan(0)
+	})
+
+	test('includes every numbered ADR file, including the template', () => {
+		return loadAdrSlugMap().then(map => {
+			expect(map['0000']).toBe('0000-template')
+			expect(map['0019']).toBe(
+				'0019-extension-based-dependency-injection-for-definecomponent',
+			)
+		})
 	})
 })
 


### PR DESCRIPTION
TypeDoc's raw output already runs through the same Markdoc pipeline as hand-authored example docs, so it can use the same components: overloaded Call Signature sections merge into a tab group instead of rendering as ambiguous duplicate headings, inherited members collapse behind a card-collapsible instead of drowning a symbol's own members in DOM/Event boilerplate, Deprecated sections get a caution callout, and inline "ADR NNNN" mentions in JSDoc link out to the ADR file on GitHub.