### PR TITLE
Version 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **`each()` callback type omitted `void`**: `each()`'s contract expects callbacks to call `watch()`/`on()`/`pass()` directly without returning anything — the idiomatic void-returning form. This compiled under TypeScript 6.x by accident: a callback with no `return` statement implicitly returns `undefined`. It does not hold under TypeScript 7, which infer the no-return case as literal `void` — not assignable to `Falsy` even though `undefined` is. The callback type is now `FactoryResult | EffectDescriptor | Falsy | void`.
+
 ## 2.3.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## 2.3.2
 
 ### Fixed
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,13 +8,13 @@
         "@zeix/cause-effect": "^1.4.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.5.5",
+        "@biomejs/biome": "^2.5.6",
         "@custom-elements-manifest/analyzer": "^0.11.0",
         "@markdoc/markdoc": "^0.5.8",
         "@playwright/test": "^1.62.0",
         "@types/bun": "^1.3.14",
         "@types/culori": "^4.0.1",
-        "@types/node": "^26.1.1",
+        "@types/node": "^26.1.2",
         "@zeix/cem-plugin-le-truc": "^0.3.2",
         "culori": "^4.0.2",
         "dompurify": "^3.4.12",
@@ -115,7 +115,7 @@
 
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.19.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw=="],
 
-    "@playwright/test": ["@playwright/test@1.62.0", "", { "dependencies": { "playwright": "1.62.0" }, "bin": { "playwright": "cli.js" } }, "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA=="],
+    "@playwright/test": ["@playwright/test@1.62.1", "", { "dependencies": { "playwright": "1.62.1" }, "bin": { "playwright": "cli.js" } }, "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ=="],
 
     "@shikijs/core": ["@shikijs/core@4.3.1", "", { "dependencies": { "@shikijs/primitive": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA=="],
 
@@ -325,9 +325,9 @@
 
     "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "playwright": ["playwright@1.62.0", "", { "dependencies": { "playwright-core": "1.62.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw=="],
+    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
 
-    "playwright-core": ["playwright-core@1.62.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA=="],
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 

--- a/examples/_common/form-associated.md
+++ b/examples/_common/form-associated.md
@@ -1,0 +1,66 @@
+{% collapsible title="Participates in HTML forms via formAssociated(), which installs the native-parity form-control contract." %}
+
+##### Properties
+
+{% table %}
+- Name
+- Type
+- Default
+- Description
+---
+- `disabled`
+- `boolean`
+- `false`
+- Whether the control is disabled; reflects the `disabled` attribute and inherits from an ancestor `<fieldset disabled>`
+---
+- `form`
+- `HTMLFormElement \| null` (readonly)
+- `null`
+- Owning `<form>` element, or `null` if none
+---
+- `labels`
+- `NodeList` (readonly)
+- empty `NodeList`
+- Associated `<label>` elements
+---
+- `name`
+- `string`
+- `''`
+- Form field name; reflects the `name` attribute
+---
+- `validationMessage`
+- `string` (readonly)
+- `''`
+- Current validation message
+---
+- `validity`
+- `ValidityState` (readonly)
+- valid
+- Current validation state
+---
+- `willValidate`
+- `boolean` (readonly)
+- `false`
+- Whether the control participates in constraint validation
+{% /table %}
+
+##### Methods
+
+{% table %}
+- Name
+- Type
+- Description
+---
+- `checkValidity`
+- `() => boolean`
+- Checks validity; returns `true` if valid
+---
+- `reportValidity`
+- `() => boolean`
+- Checks validity and reports the result to the user (e.g. validation bubble)
+---
+- `setCustomValidity`
+- `(message: string) => void`
+- Sets a custom validation error message; clears it when `message` is `''`
+{% /table %}
+{% /collapsible %}

--- a/examples/basic/gauge/basic-gauge.md
+++ b/examples/basic/gauge/basic-gauge.md
@@ -26,14 +26,19 @@ A visual gauge meter that parses the `thresholds` attribute which configures the
 - `number` (float)
 - `0`
 - Current gauge value; read from the `value` attribute (falling back to `<meter value="…">`) at connect time, and re-parsed on later `value` attribute mutations via `observedAttributes()`
----
-- `thresholds`
-- `BasicGaugeThreshold[]`
-- `[]`
-- Threshold ranges used to derive the active label and color; see below for format
 {% /table %}
 
-`BasicGaugeThreshold[]` is an array of objects sorted from highest to lowest `min`. Each entry has `min` (number), `label` (string), and `color` (CSS color string). The first entry whose `min` is ≤ `host.value` determines the active label and color. Example: `[{"min":80,"label":"Good job!","color":"var(--color-green-70)"},{"min":50,"label":"Decent","color":"var(--color-orange-70)"},{"min":0,"label":"Try again!","color":"var(--color-pink-70)"}]`
+#### Attributes
+
+{% table %}
+- Name
+- Description
+---
+- `thresholds`
+- Color-coded threshold ranges as a JSON array; read once at connect time. See below for format.
+{% /table %}
+
+`thresholds` is a `BasicGaugeThreshold[]`: an array of objects sorted from highest to lowest `min`. Each entry has `min` (number), `label` (string), and `color` (CSS color string). The first entry whose `min` is ≤ `host.value` determines the active label and color. Example: `[{"min":80,"label":"Good job!","color":"var(--color-green-70)"},{"min":50,"label":"Decent","color":"var(--color-orange-70)"},{"min":0,"label":"Try again!","color":"var(--color-pink-70)"}]`
 
 #### Descendant Elements
 

--- a/examples/form/checkbox/form-checkbox.md
+++ b/examples/form/checkbox/form-checkbox.md
@@ -1,6 +1,6 @@
 ### Form Checkbox
 
-A styledwrapper for a native checkbox with todo item and toggle switch variants.
+A styled wrapper for a native checkbox with todo item and toggle switch variants.
 
 #### Preview
 
@@ -32,6 +32,8 @@ A styledwrapper for a native checkbox with todo item and toggle switch variants.
 - Text content of `.label` or `label`
 - Label text shown next to the checkbox
 {% /table %}
+
+{% partial file="form-associated.md" /%}
 
 #### Classes
 

--- a/examples/form/colorgraph/form-colorgraph.md
+++ b/examples/form/colorgraph/form-colorgraph.md
@@ -43,6 +43,8 @@ An interactive OKLCH color picker combining a 2D lightness/chroma graph, a hue s
 - Hue angle in degrees (0–360)
 {% /table %}
 
+{% partial file="form-associated.md" /%}
+
 #### Methods
 
 {% table %}

--- a/examples/form/combobox/form-combobox.md
+++ b/examples/form/combobox/form-combobox.md
@@ -38,6 +38,8 @@ An advanced form component that coordinates a text input with a popup `form-list
 - Assistive/help text shown in `.description`
 {% /table %}
 
+{% partial file="form-associated.md" /%}
+
 #### Methods
 
 {% table %}

--- a/examples/form/inplace-edit/form-inplace-edit.md
+++ b/examples/form/inplace-edit/form-inplace-edit.md
@@ -33,6 +33,8 @@ A self-contained inline label editor. Wraps a `<span>` (label display) and an ed
 - Current label value; reactive — set via `pass()` to keep display in sync with external data
 {% /table %}
 
+{% partial file="form-associated.md" /%}
+
 #### Descendant Elements
 
 {% table %}

--- a/examples/form/listbox/form-listbox.md
+++ b/examples/form/listbox/form-listbox.md
@@ -43,6 +43,8 @@ A full-featured listbox with client-side filtering and optional remote option lo
 - URL for loading options JSON (flat or grouped)
 {% /table %}
 
+{% partial file="form-associated.md" /%}
+
 #### Descendant Elements
 
 {% table %}

--- a/examples/form/radiogroup/form-radiogroup.md
+++ b/examples/form/radiogroup/form-radiogroup.md
@@ -28,6 +28,8 @@ A roving-tabindex radio group that works both controlled and uncontrolled.
 - Value of the currently checked radio input; settable for controlled use
 {% /table %}
 
+{% partial file="form-associated.md" /%}
+
 #### Classes
 
 Use `class` attribute to get a different style for the radio group.

--- a/examples/form/spinbutton/form-spinbutton.html
+++ b/examples/form/spinbutton/form-spinbutton.html
@@ -8,6 +8,7 @@
 		value="0"
 		min="0"
 		max="10"
+		aria-label="Quantity"
 		readonly
 		disabled
 		hidden
@@ -31,6 +32,7 @@
 		value="0"
 		min="0"
 		max="5"
+		aria-label="Quantity"
 		hidden
 	>
 	<button type="button" class="increment" aria-label="Increment">
@@ -50,6 +52,7 @@
 		value="3"
 		min="0"
 		max="15"
+		aria-label="Quantity"
 		readonly
 		disabled
 	>
@@ -69,6 +72,7 @@
 		value="0"
 		min="0"
 		max="8"
+		aria-label="Quantity"
 		hidden
 	>
 	<button type="button" class="decrement" aria-label="Decrement" hidden>
@@ -91,6 +95,7 @@
 			value="0"
 			min="0"
 			max="12"
+			aria-label="Quantity"
 			hidden
 		>
 		<button type="button" class="increment" aria-label="Increment">

--- a/examples/form/spinbutton/form-spinbutton.md
+++ b/examples/form/spinbutton/form-spinbutton.md
@@ -33,6 +33,8 @@ A quantity spinbutton with increment/decrement buttons, clamped values, and keyb
 - Maximum allowed value (read from `input.max`)
 {% /table %}
 
+{% partial file="form-associated.md" /%}
+
 #### Descendant Elements
 
 {% table %}

--- a/examples/form/textbox/form-textbox.css
+++ b/examples/form/textbox/form-textbox.css
@@ -45,7 +45,7 @@ form-textbox {
 		height: var(--input-height);
 	}
 
-	&[clearable] .input {
+	&:state(clearable) .input {
 		position: relative;
 
 		& input {

--- a/examples/form/textbox/form-textbox.html
+++ b/examples/form/textbox/form-textbox.html
@@ -16,7 +16,7 @@
 
 <hr>
 
-<form-textbox name="query" clearable>
+<form-textbox name="query">
 	<label for="query-input">Search terms</label>
 	<div class="input">
 		<input

--- a/examples/form/textbox/form-textbox.md
+++ b/examples/form/textbox/form-textbox.md
@@ -1,6 +1,6 @@
 ### Form Textbox
 
-A general-purpose text field wrapper for `input` or `textarea` elements.
+A general-purpose text field wrapper for `input` or `textarea` elements. Sets the `:state(clearable)` custom state when a `button.clear` descendant is present, so CSS can reserve space for it.
 
 #### Preview
 
@@ -37,6 +37,8 @@ A general-purpose text field wrapper for `input` or `textarea` elements.
 - Text content of `.description`
 - Description/help text (or remaining characters when `data-remaining` is set)
 {% /table %}
+
+{% partial file="form-associated.md" /%}
 
 #### Methods
 

--- a/examples/form/textbox/form-textbox.ts
+++ b/examples/form/textbox/form-textbox.ts
@@ -35,12 +35,15 @@ declare global {
  * and validity are via ElementInternals (`formAssociated()`).
  * External consumers read `host.validationMessage` / `host.validity` like on a
  * native input; inline error display binds to component-internal state.
+ * Sets the `:state(clearable)` custom state when a `button.clear` descendant
+ * is present, so CSS can reserve space for it — derived from markup, not an
+ * author-set attribute, so it can't drift out of sync or be spoofed.
  *
  * @demo {https://zeixcom.github.io/le-truc/examples.html#form-textbox} Interactive preview and usage examples
  **/
 export default defineComponent<FormTextboxProps>(
 	'form-textbox',
-	({ expose, first, host, on, watch }) => {
+	({ expose, first, host, internals, on, watch }) => {
 		const textbox = first(
 			'input, textarea',
 			'Add a native input or textarea as descendant element.',
@@ -86,6 +89,7 @@ export default defineComponent<FormTextboxProps>(
 
 		const clearBtn = first('button.clear')
 		if (clearBtn) {
+			internals?.states.add('clearable')
 			on(clearBtn, 'click', () => {
 				host.clear()
 			})

--- a/examples/module/carousel/module-carousel.html
+++ b/examples/module/carousel/module-carousel.html
@@ -1,6 +1,6 @@
 <module-carousel>
 	<h2 class="visually-hidden">Slides</h2>
-	<div class="slides">
+	<div class="slides" tabindex="0">
 		<div id="slide1" role="tabpanel" aria-current="true">
 			<h3>Slide 1</h3>
 			<basic-hello>

--- a/examples/module/scrollarea/module-scrollarea.md
+++ b/examples/module/scrollarea/module-scrollarea.md
@@ -1,6 +1,6 @@
 ### Module Scrollarea
 
-A scroll container that tracks overflow state using an`IntersectionObserver`, exposing component-owned custom states (`:state(overflow)`, `:state(overflow-start)`, `:state(overflow-end)`).
+A scroll container that tracks overflow state using an`IntersectionObserver`, exposing component-owned custom states (`:state(overflow)`, `:state(overflow-start)`, `:state(overflow-end)`). While content overflows, the host becomes keyboard-focusable (`tabindex="0"`) so it can be scrolled without a pointer; the attribute is removed again once overflow ends.
 
 #### Preview
 

--- a/examples/module/scrollarea/module-scrollarea.ts
+++ b/examples/module/scrollarea/module-scrollarea.ts
@@ -76,7 +76,13 @@ export default defineComponent(
 
 		watch(hasOverflow, bindState(internals, 'overflow'))
 		watch(hasOverflow, overflow => {
-			host.tabIndex = overflow ? 0 : -1
+			// Only set tabindex="0" explicitly; never force -1. An explicit -1
+			// opts the element out of Chromium's native "sequentially focusable
+			// scrolling regions" heuristic, which — during the async gap before
+			// this effect first runs — can leave a containing modal <dialog>
+			// with a single tab stop, letting focus escape the modal.
+			if (overflow) host.setAttribute('tabindex', '0')
+			else host.removeAttribute('tabindex')
 		})
 		watch(overflowStart, bindState(internals, 'overflow-start'))
 		watch(overflowEnd, bindState(internals, 'overflow-end'))

--- a/examples/module/scrollarea/module-scrollarea.ts
+++ b/examples/module/scrollarea/module-scrollarea.ts
@@ -75,6 +75,9 @@ export default defineComponent(
 		})
 
 		watch(hasOverflow, bindState(internals, 'overflow'))
+		watch(hasOverflow, overflow => {
+			host.tabIndex = overflow ? 0 : -1
+		})
 		watch(overflowStart, bindState(internals, 'overflow-start'))
 		watch(overflowEnd, bindState(internals, 'overflow-end'))
 		watch(

--- a/examples/module/splitview/module-splitview.css
+++ b/examples/module/splitview/module-splitview.css
@@ -3,12 +3,12 @@ module-splitview {
 	grid-template-columns: var(--module-splitview-ratio, 50%) var(--space-xs) 1fr;
 	overflow: hidden;
 
-	& .panel {
+	& module-scrollarea {
 		min-width: 0;
 		min-height: 0;
 	}
 
-	& .divider {
+	.divider {
 		display: flex;
 		align-items: center;
 		justify-content: center;

--- a/examples/module/splitview/module-splitview.css
+++ b/examples/module/splitview/module-splitview.css
@@ -4,7 +4,6 @@ module-splitview {
 	overflow: hidden;
 
 	& .panel {
-		overflow: auto;
 		min-width: 0;
 		min-height: 0;
 	}

--- a/examples/module/splitview/module-splitview.html
+++ b/examples/module/splitview/module-splitview.html
@@ -1,9 +1,11 @@
 <!-- Horizontal split (default) -->
 <module-splitview id="horizontal-splitview">
-	<div class="panel">
-		<p>Left panel</p>
-		<p>Drag the handle or focus it and use arrow keys to resize.</p>
-	</div>
+	<module-scrollarea class="panel">
+		<div>
+			<p>Left panel</p>
+			<p>Drag the handle or focus it and use arrow keys to resize.</p>
+		</div>
+	</module-scrollarea>
 	<button
 		type="button"
 		class="divider"
@@ -14,19 +16,23 @@
 		aria-valuemin="10"
 		aria-valuemax="90"
 	></button>
-	<div class="panel">
-		<p>Right panel</p>
-		<p>The proportions are kept when the container is resized.</p>
-	</div>
+	<module-scrollarea class="panel">
+		<div>
+			<p>Right panel</p>
+			<p>The proportions are kept when the container is resized.</p>
+		</div>
+	</module-scrollarea>
 </module-splitview>
 
 <hr>
 
 <!-- Pre-set split position via attribute -->
 <module-splitview id="preset-splitview" split="0.3">
-	<div class="panel">
-		<p>Narrow panel (30%)</p>
-	</div>
+	<module-scrollarea class="panel">
+		<div>
+			<p>Narrow panel (30%)</p>
+		</div>
+	</module-scrollarea>
 	<button
 		type="button"
 		class="divider"
@@ -37,18 +43,22 @@
 		aria-valuemin="10"
 		aria-valuemax="90"
 	></button>
-	<div class="panel">
-		<p>Wide panel (70%)</p>
-	</div>
+	<module-scrollarea class="panel">
+		<div>
+			<p>Wide panel (70%)</p>
+		</div>
+	</module-scrollarea>
 </module-splitview>
 
 <hr>
 
 <!-- Vertical split -->
 <module-splitview id="vertical-splitview" orientation="vertical">
-	<div class="panel">
-		<p>Top panel</p>
-	</div>
+	<module-scrollarea class="panel">
+		<div>
+			<p>Top panel</p>
+		</div>
+	</module-scrollarea>
 	<button
 		type="button"
 		class="divider"
@@ -59,7 +69,9 @@
 		aria-valuemin="10"
 		aria-valuemax="90"
 	></button>
-	<div class="panel">
-		<p>Bottom panel</p>
-	</div>
+	<module-scrollarea class="panel">
+		<div>
+			<p>Bottom panel</p>
+		</div>
+	</module-scrollarea>
 </module-splitview>

--- a/examples/module/splitview/module-splitview.html
+++ b/examples/module/splitview/module-splitview.html
@@ -1,6 +1,6 @@
 <!-- Horizontal split (default) -->
 <module-splitview id="horizontal-splitview">
-	<module-scrollarea class="panel">
+	<module-scrollarea>
 		<div>
 			<p>Left panel</p>
 			<p>Drag the handle or focus it and use arrow keys to resize.</p>
@@ -16,7 +16,7 @@
 		aria-valuemin="10"
 		aria-valuemax="90"
 	></button>
-	<module-scrollarea class="panel">
+	<module-scrollarea>
 		<div>
 			<p>Right panel</p>
 			<p>The proportions are kept when the container is resized.</p>
@@ -28,7 +28,7 @@
 
 <!-- Pre-set split position via attribute -->
 <module-splitview id="preset-splitview" split="0.3">
-	<module-scrollarea class="panel">
+	<module-scrollarea>
 		<div>
 			<p>Narrow panel (30%)</p>
 		</div>
@@ -43,7 +43,7 @@
 		aria-valuemin="10"
 		aria-valuemax="90"
 	></button>
-	<module-scrollarea class="panel">
+	<module-scrollarea>
 		<div>
 			<p>Wide panel (70%)</p>
 		</div>
@@ -54,7 +54,7 @@
 
 <!-- Vertical split -->
 <module-splitview id="vertical-splitview" orientation="vertical">
-	<module-scrollarea class="panel">
+	<module-scrollarea>
 		<div>
 			<p>Top panel</p>
 		</div>
@@ -69,7 +69,7 @@
 		aria-valuemin="10"
 		aria-valuemax="90"
 	></button>
-	<module-scrollarea class="panel">
+	<module-scrollarea>
 		<div>
 			<p>Bottom panel</p>
 		</div>

--- a/examples/module/splitview/module-splitview.md
+++ b/examples/module/splitview/module-splitview.md
@@ -54,7 +54,7 @@ A two-panel resizable container with a drag handle between the panels, supportin
 - **required**
 - The resize handle; carries `role="separator"` and `aria-valuenow/min/max`
 ---
-- `.panel` (×2)
+- `module-scrollarea` (×2)
 - `HTMLElement`
 - **required**
 - The two resizable content areas; sized by the CSS grid via `--module-splitview-ratio`. Use a `module-scrollarea` for each panel so overflowing content stays keyboard-accessible.

--- a/examples/module/splitview/module-splitview.md
+++ b/examples/module/splitview/module-splitview.md
@@ -57,5 +57,5 @@ A two-panel resizable container with a drag handle between the panels, supportin
 - `.panel` (×2)
 - `HTMLElement`
 - **required**
-- The two resizable content areas; sized by the CSS grid via `--split`
+- The two resizable content areas; sized by the CSS grid via `--module-splitview-ratio`. Use a `module-scrollarea` for each panel so overflowing content stays keyboard-accessible.
 {% /table %}

--- a/examples/module/todo/module-todo.css
+++ b/examples/module/todo/module-todo.css
@@ -4,11 +4,11 @@ module-todo {
 	gap: var(--space-l);
 	container-type: inline-size;
 
-	&[filter="completed"] [data-container] li:not(:has(input:checked)) {
+	&:state(filter-completed) [data-container] li:not(:has(input:checked)) {
 		display: none;
 	}
 
-	&[filter="active"] [data-container] li:has(input:checked) {
+	&:state(filter-active) [data-container] li:has(input:checked) {
 		display: none;
 	}
 

--- a/examples/module/todo/module-todo.html
+++ b/examples/module/todo/module-todo.html
@@ -1,6 +1,6 @@
-<module-todo filter="all">
+<module-todo>
 	<form action="#">
-		<form-textbox clearable>
+		<form-textbox>
 			<label for="add-todo">What needs to be done?</label>
 			<div class="input">
 				<input id="add-todo" type="text" value="">

--- a/examples/module/todo/module-todo.md
+++ b/examples/module/todo/module-todo.md
@@ -1,6 +1,6 @@
 ### Module Todo
 
-A todo component that owns the data, manages the list DOM directly, and handles all interactions — adding, deleting, reordering (keyboard and drag), editing labels, and toggling completion.
+A todo component that owns the data, manages the list DOM directly, and handles all interactions — adding, deleting, reordering (keyboard and drag), editing labels, and toggling completion. Exposes the active filter as custom states (`:state(filter-active)`, `:state(filter-completed)`) for CSS-based item visibility.
 
 #### Preview
 
@@ -16,7 +16,7 @@ A todo component that owns the data, manages the list DOM directly, and handles 
 
 #### Reactive Properties
 
-None. This component orchestrates behavior by passing state and events between descendants.
+None. This component orchestrates behavior by passing state and events between descendants, and sets custom states (matched in CSS via `:state()`) based on the active filter.
 
 #### Descendant Elements
 

--- a/examples/module/todo/module-todo.spec.ts
+++ b/examples/module/todo/module-todo.spec.ts
@@ -11,6 +11,18 @@ function isHostChecked(element: Locator): Promise<boolean> {
 }
 
 /**
+ * Check whether a custom state (ElementInternals `states`) is set on the
+ * element, via the `:state()` pseudo-class. Evaluated in the browser because
+ * Playwright's own selector engine does not parse `:state()`.
+ */
+function hasState(element: Locator, state: string): Promise<boolean> {
+	return element.evaluate(
+		(el: Element, s: string) => el.matches(`:state(${s})`),
+		state,
+	)
+}
+
+/**
  * Test Suite: module-todo Component
  *
  * Comprehensive tests for the Le Truc module-todo component, which provides
@@ -386,15 +398,18 @@ test.describe('module-todo component', () => {
 
 			// Switch to "Active" filter
 			await filter.locator('label').filter({ hasText: 'Active' }).click()
-			await expect(todo).toHaveAttribute('filter', 'active')
+			await expect.poll(() => hasState(todo, 'filter-active')).toBe(true)
+			await expect.poll(() => hasState(todo, 'filter-completed')).toBe(false)
 
 			// Switch to "Completed" filter
 			await filter.locator('label').filter({ hasText: 'Completed' }).click()
-			await expect(todo).toHaveAttribute('filter', 'completed')
+			await expect.poll(() => hasState(todo, 'filter-completed')).toBe(true)
+			await expect.poll(() => hasState(todo, 'filter-active')).toBe(false)
 
 			// Switch back to "All"
 			await filter.locator('label').filter({ hasText: 'All' }).click()
-			await expect(todo).toHaveAttribute('filter', 'all')
+			await expect.poll(() => hasState(todo, 'filter-active')).toBe(false)
+			await expect.poll(() => hasState(todo, 'filter-completed')).toBe(false)
 		})
 	})
 

--- a/examples/module/todo/module-todo.ts
+++ b/examples/module/todo/module-todo.ts
@@ -1,6 +1,6 @@
 import {
-	bindAttribute,
 	bindProperty,
+	bindState,
 	bindText,
 	createList,
 	createMemo,
@@ -36,11 +36,13 @@ let idCounter = 0
  * A full-featured todo list with add, remove, complete, filter, and drag-and-drop reordering.
  * Use it as a reference example of a complete Le Truc application — keyboard accessible
  * controls and ARIA labelling should be considered when adapting it for production use.
+ * Exposes the active filter as custom states (`:state(filter-active)`, `:state(filter-completed)`)
+ * for CSS-based item visibility, so filter state cannot be spoofed by setting an attribute.
  * @demo {https://zeixcom.github.io/le-truc/examples.html#module-todo} Interactive preview and usage examples
  **/
 export default defineComponent(
 	'module-todo',
-	({ all, first, host, on, pass, watch }) => {
+	({ all, first, host, internals, on, pass, watch }) => {
 		const container = first(
 			'[data-container]',
 			'Add a container element for items.',
@@ -349,7 +351,14 @@ export default defineComponent(
 			'form-radiogroup',
 			'Add <form-radiogroup> component to filter todo items.',
 		)
-		watch(() => filter.value || 'all', bindAttribute(host, 'filter'))
+		watch(
+			() => (filter.value || 'all') === 'active',
+			bindState(internals, 'filter-active'),
+		)
+		watch(
+			() => (filter.value || 'all') === 'completed',
+			bindState(internals, 'filter-completed'),
+		)
 
 		watch(status, bindText(liveRegion))
 	},

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-// Le Truc 2.3.1
+// Le Truc 2.3.2
 
 // From Cause & Effect
 export {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
 		"@biomejs/biome": "^2.5.6",
 		"@custom-elements-manifest/analyzer": "^0.11.0",
 		"@markdoc/markdoc": "^0.5.8",
-		"@playwright/test": "^1.62.0",
+		"@playwright/test": "^1.62.1",
 		"@types/bun": "^1.3.14",
 		"@types/culori": "^4.0.1",
 		"@types/node": "^26.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zeix/le-truc",
-	"version": "2.3.1",
+	"version": "2.3.2",
 	"description": "Le Truc - the thing for type-safe reactive web components",
 	"keywords": [
 		"Le Truc",

--- a/server/config.ts
+++ b/server/config.ts
@@ -10,6 +10,7 @@ const ROOT = join(import.meta.dir, '..')
 
 // Path constants
 const SRC_DIR = join(ROOT, 'src')
+const ADR_DIR = join(ROOT, 'adr')
 
 const COMPONENTS_DIR = join(ROOT, 'examples')
 const CSS_FILE = join(ROOT, 'examples/main.css')
@@ -111,6 +112,7 @@ const COMPRESSIBLE_TYPES = [
 ] as const
 
 export {
+	ADR_DIR,
 	API_DIR,
 	ASSETS_DIR,
 	BASE_URL,

--- a/server/effects/api-pages.ts
+++ b/server/effects/api-pages.ts
@@ -4,10 +4,15 @@ import Markdoc, {
 	Tag,
 } from '@markdoc/markdoc'
 import { createEffect, match } from '@zeix/cause-effect'
-import { API_DIR, OUTPUT_DIR } from '../config'
+import { ADR_DIR, API_DIR, OUTPUT_DIR } from '../config'
 import { apiMarkdown, type FileInfo } from '../file-signals'
 import { highlightCodeBlocks } from '../html-shaping'
-import { getFilePath, getRelativePath, writeFileSafe } from '../io'
+import {
+	getDirectoryEntries,
+	getFilePath,
+	getRelativePath,
+	writeFileSafe,
+} from '../io'
 import markdocConfig from '../markdoc.config'
 
 /* === Internal Functions === */
@@ -49,6 +54,58 @@ const linkExternalDefinedIn = (content: string): string =>
 			return `Defined in: [${path}.ts](https://github.com/${repo}/blob/main/${path}.ts)`
 		},
 	)
+
+/**
+ * Matches an "ADR NNNN" mention anywhere in prose, not anchored to a specific
+ * surrounding phrase or trailing punctuation — the codebase's actual JSDoc
+ * convention varies ("See ADR 0011.", "see ADR 0007)", "See ADR 0017 for
+ * full rationale..."). Case-insensitive as a safety margin; the acronym is
+ * written "ADR" everywhere observed.
+ */
+const ADR_REFERENCE = /\bADR (\d{4})\b/gi
+
+/**
+ * List `adr/` and map ADR number to its filename slug (without extension),
+ * so inline "See ADR NNNN." prose can be turned into a real link. Not cached:
+ * re-reading is cheap (a couple dozen tiny files) and picks up newly recorded
+ * ADRs immediately under HMR/file-watch rebuilds, same reasoning as
+ * `loadPartials()` in effects/examples.ts.
+ */
+const loadAdrSlugMap = async (): Promise<Record<string, string>> => {
+	const entries = await getDirectoryEntries(ADR_DIR)
+	const map: Record<string, string> = {}
+	for (const entry of entries) {
+		if (!entry.isFile()) continue
+		const match = entry.name.match(/^(\d{4})-.+\.md$/)
+		if (match) map[match[1]!] = entry.name.replace(/\.md$/, '')
+	}
+	return map
+}
+
+/**
+ * Rewrite inline "ADR NNNN" mentions (plain prose in JSDoc, TypeDoc emits
+ * them unlinked) into a link to the ADR file on GitHub — this pipeline
+ * doesn't ship `adr/` into `docs/`, so link out rather than to a local path,
+ * same reasoning `linkExternalDefinedIn` uses for `node_modules` dependency
+ * source links. Only the "ADR NNNN" span itself is replaced, leaving
+ * surrounding punctuation/phrasing untouched, so this reads correctly
+ * whether the mention is "See ADR 0011.", mid-sentence ("see ADR 0007)"),
+ * or followed by more prose ("See ADR 0017 for full rationale"). An ADR
+ * number with no matching file (typo, renumbered) is left as plain text
+ * with a warning rather than thrown.
+ */
+const linkAdrReferences = (
+	content: string,
+	adrSlugs: Record<string, string>,
+): string =>
+	content.replace(ADR_REFERENCE, (match, number: string) => {
+		const slug = adrSlugs[number]
+		if (!slug) {
+			console.warn(`No ADR file found for referenced ADR ${number}`)
+			return match
+		}
+		return `[ADR ${number}](https://github.com/zeixcom/le-truc/blob/main/adr/${slug}.md)`
+	})
 
 /** Recursively read the first text content of a renderable node */
 const firstTextContent = (node: RenderableTreeNode): string => {
@@ -302,6 +359,318 @@ const convertParameterSectionsToTables = (
 }
 
 /**
+ * Wrap the content following a "Deprecated" heading in a loud `caution`
+ * `card-callout` with a title (same shape server/schema/callout.markdoc.ts
+ * produces), dropping the original heading since the callout carries that
+ * meaning now — this is the case that should actually catch a reader's eye.
+ *
+ * "Since" deliberately does NOT get this treatment: every `card-callout`
+ * class (including `.note`) renders as a full padded/bordered/icon box in
+ * `examples/card/callout/card-callout.css` — there's no quiet variant — and
+ * "Since" appears on nearly every symbol (multiple times on anything
+ * overloaded, e.g. 6× on createSignal.html), so wrapping it produced a wall
+ * of colored boxes for a single version string. Left as plain text.
+ */
+const wrapDeprecatedCallout = (
+	root: RenderableTreeNodes,
+): RenderableTreeNodes => {
+	if (!Tag.isTag(root)) return root
+
+	const children: RenderableTreeNode[] = []
+	const siblings = root.children
+	let i = 0
+	while (i < siblings.length) {
+		const node = siblings[i]!
+		const level = headingTagLevel(node)
+		const text = level !== null ? headingTagText(node) : null
+
+		if (text === 'Deprecated') {
+			const body: RenderableTreeNode[] = []
+			let j = i + 1
+			while (j < siblings.length && headingTagLevel(siblings[j]!) === null) {
+				body.push(siblings[j]!)
+				j++
+			}
+			if (body.length === 0) {
+				children.push(node)
+				i++
+				continue
+			}
+			children.push(
+				new Tag('card-callout', { class: 'caution' }, [
+					new Tag('p', {}, [new Tag('strong', {}, ['Deprecated'])]),
+					...body,
+				]),
+			)
+			i = j
+			continue
+		}
+		children.push(node)
+		i++
+	}
+	return new Tag(root.name, root.attributes, children)
+}
+
+const CALL_SIGNATURE_LABEL = 'Call Signature'
+
+/**
+ * Collect the body of a single "Call Signature" section: everything after
+ * the heading up to (not including) the next "Call Signature" heading (next
+ * overload) or a heading whose text isn't a recognized sub-section label (a
+ * new symbol/section entirely, not part of this overload). Heading *level*
+ * isn't a reliable boundary here — TypeDoc's h6-depth-ceiling clamping can
+ * put a Call Signature's own children (Returns, Inherited from, ...) at a
+ * shallower level than the Call Signature heading itself (see
+ * `composedPath()` in ContextRequestEvent.md, an inherited DOM overload).
+ */
+const collectCallSignatureBody = (
+	siblings: RenderableTreeNode[],
+	startIndex: number,
+): { body: RenderableTreeNode[]; nextIndex: number } => {
+	const body: RenderableTreeNode[] = []
+	let i = startIndex
+	while (i < siblings.length) {
+		const node = siblings[i]!
+		const level = headingTagLevel(node)
+		if (level !== null) {
+			const text = headingTagText(node)
+			if (text === CALL_SIGNATURE_LABEL) break
+			if (!PARAM_SECTION_STOP_LABELS.has(text)) break
+		}
+		body.push(node)
+		i++
+	}
+	return { body, nextIndex: i }
+}
+
+/**
+ * Tab structure identical to what server/schema/tabgroup.markdoc.ts produces.
+ * `groupIndex` disambiguates ids across multiple overloaded methods on the
+ * same page (e.g. ContextRequestEvent.md has overloads on both
+ * composedPath() and preventDefault()) — without it every tab group would
+ * emit the same "panel_overload-1"/"panel_overload-2" ids, which is invalid
+ * HTML and breaks aria-controls/aria-labelledby wiring.
+ */
+const buildOverloadTabGroup = (
+	groups: RenderableTreeNode[][],
+	groupIndex: number,
+): Tag => {
+	const tabs = groups.map((body, index) => ({
+		label: `Overload ${index + 1}`,
+		id: `panel_overload-${groupIndex}-${index + 1}`,
+		body,
+	}))
+
+	const tablist = new Tag(
+		'div',
+		{ role: 'tablist' },
+		tabs.map((tab, index) => {
+			const isSelected = index === 0
+			const triggerId = tab.id.replace('panel_', 'trigger_')
+			return new Tag(
+				'button',
+				{
+					role: 'tab',
+					id: triggerId,
+					'aria-controls': tab.id,
+					'aria-selected': String(isSelected),
+					tabindex: isSelected ? '0' : '-1',
+				},
+				[tab.label],
+			)
+		}),
+	)
+
+	const tabpanels = tabs.map((tab, index) => {
+		const isSelected = index === 0
+		const triggerId = tab.id.replace('panel_', 'trigger_')
+		const attributes: Record<string, string> = {
+			role: 'tabpanel',
+			id: tab.id,
+			'aria-labelledby': triggerId,
+		}
+		if (!isSelected) attributes.hidden = ''
+		return new Tag('div', attributes, [new Tag(undefined, {}, tab.body)])
+	})
+
+	return new Tag('module-tabgroup', {}, [tablist, ...tabpanels])
+}
+
+/**
+ * TypeDoc emits one "Call Signature" heading per overload, all as siblings
+ * under the same symbol heading, with no label distinguishing one overload
+ * from another (e.g. createElementsMemo()'s two generic signatures, or
+ * composedPath()'s inherited DOM overloads). Replace ≥2 consecutive Call
+ * Signature groups with a tab group labeled "Overload 1", "Overload 2", etc.
+ * A lone Call Signature (no sibling) is left untouched.
+ */
+const mergeOverloadCallSignatures = (
+	root: RenderableTreeNodes,
+): RenderableTreeNodes => {
+	if (!Tag.isTag(root)) return root
+
+	const children: RenderableTreeNode[] = []
+	const siblings = root.children
+	let groupCount = 0
+	let i = 0
+	while (i < siblings.length) {
+		const node = siblings[i]!
+		const level = headingTagLevel(node)
+		const text = level !== null ? headingTagText(node) : null
+
+		if (text === CALL_SIGNATURE_LABEL) {
+			const groups: RenderableTreeNode[][] = []
+			let j = i
+			while (
+				j < siblings.length &&
+				headingTagLevel(siblings[j]!) !== null &&
+				headingTagText(siblings[j]!) === CALL_SIGNATURE_LABEL
+			) {
+				const { body, nextIndex } = collectCallSignatureBody(siblings, j + 1)
+				groups.push(body)
+				j = nextIndex
+			}
+
+			if (groups.length < 2) {
+				children.push(node, ...groups[0]!)
+				i = j
+				continue
+			}
+
+			groupCount++
+			children.push(buildOverloadTabGroup(groups, groupCount))
+			i = j
+			continue
+		}
+
+		children.push(node)
+		i++
+	}
+	return new Tag(root.name, root.attributes, children)
+}
+
+type MemberEntry = {
+	heading: RenderableTreeNode
+	body: RenderableTreeNode[]
+}
+
+/**
+ * Collect "member heading + body" entries directly under a Properties/Methods
+ * section heading, one level deeper. Unlike `extractNamedRows`, member bodies
+ * can contain their own sub-headings (Inherited from, Deprecated, Call
+ * Signature, ...) at deeper levels — only a heading at exactly
+ * `sectionLevel + 1` starts a new member; anything deeper is body content,
+ * and anything at `sectionLevel` or shallower ends the section. Properties/
+ * Methods headings sit at a shallow level in practice (never near the h6
+ * ceiling `extractNamedRows` has to guard against), so this simpler
+ * level-only check is sufficient here.
+ */
+const extractMemberEntries = (
+	siblings: RenderableTreeNode[],
+	startIndex: number,
+	sectionLevel: number,
+): { entries: MemberEntry[]; nextIndex: number } | null => {
+	const entries: MemberEntry[] = []
+	let current: MemberEntry | null = null
+	let i = startIndex
+	while (i < siblings.length) {
+		const node = siblings[i]!
+		const level = headingTagLevel(node)
+		if (level !== null && level <= sectionLevel) break
+		if (level === sectionLevel + 1) {
+			current = { heading: node, body: [] }
+			entries.push(current)
+			i++
+			continue
+		}
+		if (!current) return null
+		current.body.push(node)
+		i++
+	}
+	if (entries.length === 0) return null
+	return { entries, nextIndex: i }
+}
+
+/** Recursively search a node list for a heading with the given exact text. */
+const containsHeadingText = (
+	nodes: RenderableTreeNode[],
+	text: string,
+): boolean =>
+	nodes.some(node => {
+		if (!Tag.isTag(node)) return false
+		if (headingTagLevel(node) !== null) return headingTagText(node) === text
+		return containsHeadingText(node.children, text)
+	})
+
+/** Collapsible structure identical to server/schema/collapsible.markdoc.ts. */
+const buildInheritedMembersCollapsible = (entries: MemberEntry[]): Tag => {
+	const content = entries.flatMap(entry => [entry.heading, ...entry.body])
+	return new Tag('card-collapsible', {}, [
+		new Tag('details', {}, [
+			new Tag('summary', {}, [
+				new Tag('span', { class: 'description' }, [
+					`Inherited members (${entries.length})`,
+				]),
+			]),
+			new Tag('div', { class: 'content' }, content),
+		]),
+	])
+}
+
+const MEMBER_SECTION_LABELS = new Set(['Properties', 'Methods'])
+
+/**
+ * Classes/interfaces extending a large native type are dominated by inherited
+ * boilerplate (e.g. FormAssociatedElement.md: 314 inherited vs. 255 own
+ * members). Within each Properties/Methods section, pull out any member
+ * whose body contains a descendant "Inherited from" heading — recursively,
+ * so members already re-nested by `mergeOverloadCallSignatures` (which runs
+ * first) are still found — and group them into a single collapsible appended
+ * after the own members, which stay inline in original order.
+ */
+const collapseInheritedMembers = (
+	root: RenderableTreeNodes,
+): RenderableTreeNodes => {
+	if (!Tag.isTag(root)) return root
+
+	const children: RenderableTreeNode[] = []
+	const siblings = root.children
+	let i = 0
+	while (i < siblings.length) {
+		const node = siblings[i]!
+		const level = headingTagLevel(node)
+		const text = level !== null ? headingTagText(node) : null
+
+		if (level !== null && MEMBER_SECTION_LABELS.has(text!)) {
+			const extracted = extractMemberEntries(siblings, i + 1, level)
+			if (extracted) {
+				const ownEntries: MemberEntry[] = []
+				const inheritedEntries: MemberEntry[] = []
+				for (const entry of extracted.entries) {
+					if (containsHeadingText(entry.body, 'Inherited from')) {
+						inheritedEntries.push(entry)
+					} else {
+						ownEntries.push(entry)
+					}
+				}
+				children.push(node)
+				for (const entry of ownEntries)
+					children.push(entry.heading, ...entry.body)
+				if (inheritedEntries.length > 0) {
+					children.push(buildInheritedMembersCollapsible(inheritedEntries))
+				}
+				i = extracted.nextIndex
+				continue
+			}
+		}
+
+		children.push(node)
+		i++
+	}
+	return new Tag(root.name, root.attributes, children)
+}
+
+/**
  * Headings built by createAccessibleHeading() carry generic labels ("Parameters",
  * "Returns", "Inherited from", "Call Signature") that repeat across every constructor,
  * property, and method on a generated API page, producing duplicate ids. Walk the page
@@ -408,7 +777,10 @@ const makeHeadingIdsUnique = (
  * Fragments are suitable for injection by module-lazyload (no doctype/head/body).
  * The server applies the full api.html layout on-the-fly for direct navigation.
  */
-const processApiFile = async (file: FileInfo): Promise<void> => {
+const processApiFile = async (
+	file: FileInfo,
+	adrSlugs: Record<string, string>,
+): Promise<void> => {
 	const relativePath = getRelativePath(API_DIR, file.path)
 	if (!relativePath) return
 
@@ -422,8 +794,12 @@ const processApiFile = async (file: FileInfo): Promise<void> => {
 		return
 	}
 
-	// Strip TypeDoc navigation breadcrumbs and link external "Defined in:" paths
-	const cleanContent = linkExternalDefinedIn(stripBreadcrumbs(file.content))
+	// Strip TypeDoc navigation breadcrumbs, link external "Defined in:" paths
+	// and inline "See ADR NNNN." references
+	const cleanContent = linkAdrReferences(
+		linkExternalDefinedIn(stripBreadcrumbs(file.content)),
+		adrSlugs,
+	)
 
 	// Parse with Markdoc
 	const ast = Markdoc.parse(cleanContent)
@@ -432,9 +808,19 @@ const processApiFile = async (file: FileInfo): Promise<void> => {
 		console.warn(`Markdoc validation warnings for ${relativePath}:`, errors)
 	}
 
+	// Passes that scan the flat top-level tree must run before the passes
+	// that nest content (tabs, collapsibles) — nesting passes only need to
+	// run in an order where each still finds what it depends on; see the
+	// doc comments on collectCallSignatureBody/collapseInheritedMembers.
 	const transformed = makeHeadingIdsUnique(
-		convertParameterSectionsToTables(
-			mergeDefinedInIntoBlockquote(Markdoc.transform(ast, markdocConfig)),
+		collapseInheritedMembers(
+			mergeOverloadCallSignatures(
+				wrapDeprecatedCallout(
+					convertParameterSectionsToTables(
+						mergeDefinedInIntoBlockquote(Markdoc.transform(ast, markdocConfig)),
+					),
+				),
+			),
 		),
 	)
 	let htmlContent = Markdoc.renderers.html(transformed)
@@ -473,11 +859,16 @@ const processApiFile = async (file: FileInfo): Promise<void> => {
 
 // Exported for testing
 export {
+	collapseInheritedMembers,
 	convertParameterSectionsToTables,
+	linkAdrReferences,
 	linkExternalDefinedIn,
+	loadAdrSlugMap,
 	makeHeadingIdsUnique,
 	mergeDefinedInIntoBlockquote,
+	mergeOverloadCallSignatures,
 	stripBreadcrumbs,
+	wrapDeprecatedCallout,
 }
 
 export const apiPagesEffect = (onRebuild?: () => void) => {
@@ -492,10 +883,11 @@ export const apiPagesEffect = (onRebuild?: () => void) => {
 				try {
 					console.log('📖 Generating API page fragments...')
 
+					const adrSlugs = await loadAdrSlugMap()
 					let count = 0
 					const processPromises = apiFiles.map(async (file: FileInfo) => {
 						try {
-							await processApiFile(file)
+							await processApiFile(file, adrSlugs)
 							count++
 						} catch (error) {
 							console.error(`Failed to process API file ${file.path}:`, error)

--- a/server/effects/examples.ts
+++ b/server/effects/examples.ts
@@ -1,4 +1,5 @@
-import Markdoc from '@markdoc/markdoc'
+import { join } from 'node:path'
+import Markdoc, { type Node } from '@markdoc/markdoc'
 import { createEffect, match } from '@zeix/cause-effect'
 import { COMPONENTS_DIR, CONTENT_MARKER, EXAMPLES_DIR } from '../config'
 import {
@@ -18,6 +19,24 @@ const toPathMap = (files: FileInfo[]): Map<string, FileInfo> => {
 	return map
 }
 
+// Shared fragments referenced via Markdoc's built-in `{% partial file="..." /%}`
+// tag. Keyed by the exact `file` attribute value used in component docs.
+const PARTIALS: Record<string, string> = {
+	'form-associated.md': join(COMPONENTS_DIR, '_common', 'form-associated.md'),
+}
+
+// Not cached across calls: re-reading picks up edits to the fragment file
+// immediately under HMR/file-watch rebuilds, and the files are tiny.
+const loadPartials = async (): Promise<Record<string, Node>> => {
+	const entries = await Promise.all(
+		Object.entries(PARTIALS).map(async ([name, path]) => {
+			const content = await Bun.file(path).text()
+			return [name, Markdoc.parse(content)] as const
+		}),
+	)
+	return Object.fromEntries(entries)
+}
+
 const processExample = async (
 	componentName: string,
 	markdownContent: string,
@@ -32,14 +51,17 @@ const processExample = async (
 	// Parse with Markdoc
 	const ast = Markdoc.parse(processedContent)
 
+	const partials = await loadPartials()
+	const config = { ...markdocConfig, partials }
+
 	// Validate the document
-	const errors = Markdoc.validate(ast, markdocConfig)
+	const errors = Markdoc.validate(ast, config)
 	if (errors.length > 0) {
 		console.warn(`Markdoc validation errors for ${componentName}:`, errors)
 	}
 
 	// Transform the AST
-	const transformed = Markdoc.transform(ast, markdocConfig)
+	const transformed = Markdoc.transform(ast, config)
 
 	// Render to HTML
 	let htmlContent = Markdoc.renderers.html(transformed)

--- a/server/markdoc.config.ts
+++ b/server/markdoc.config.ts
@@ -3,6 +3,7 @@ import blogpost from './schema/blogpost.markdoc'
 import callout from './schema/callout.markdoc'
 import carousel from './schema/carousel.markdoc'
 import cemList from './schema/cem-list.markdoc'
+import collapsible from './schema/collapsible.markdoc'
 import demo from './schema/demo.markdoc'
 import fence from './schema/fence.markdoc'
 import heading from './schema/heading.markdoc'
@@ -25,6 +26,7 @@ export const markdocConfig = {
 		callout,
 		carousel,
 		'cem-list': cemList,
+		collapsible,
 		demo,
 		listnav,
 		sources,

--- a/server/schema/carousel.markdoc.ts
+++ b/server/schema/carousel.markdoc.ts
@@ -78,7 +78,7 @@ const carousel: Schema = {
 		// Create slides container
 		const slidesContainer = new Tag(
 			'div',
-			{ class: 'slides' },
+			{ class: 'slides', tabindex: '0' },
 			slides.map(s => s.slide),
 		)
 

--- a/server/schema/collapsible.markdoc.ts
+++ b/server/schema/collapsible.markdoc.ts
@@ -1,0 +1,25 @@
+import { type Config, type Node, type Schema, Tag } from '@markdoc/markdoc'
+import { requiredTitleAttribute, richChildren } from '../markdoc-constants'
+import { transformChildrenWithConfig } from '../markdoc-helpers'
+
+const collapsible: Schema = {
+	render: 'card-collapsible',
+	children: [...richChildren, 'table'],
+	attributes: {
+		title: requiredTitleAttribute,
+	},
+	transform(node: Node, config: Config) {
+		const { title } = node.attributes
+		const children = transformChildrenWithConfig(node.children ?? [], config)
+		return new Tag('card-collapsible', {}, [
+			new Tag('details', {}, [
+				new Tag('summary', {}, [
+					new Tag('span', { class: 'description' }, [title]),
+				]),
+				new Tag('div', { class: 'content' }, children),
+			]),
+		])
+	},
+}
+
+export default collapsible

--- a/server/tests/effects/api-pages.test.ts
+++ b/server/tests/effects/api-pages.test.ts
@@ -8,11 +8,16 @@
 import { describe, expect, test } from 'bun:test'
 import Markdoc from '@markdoc/markdoc'
 import {
+	collapseInheritedMembers,
 	convertParameterSectionsToTables,
+	linkAdrReferences,
 	linkExternalDefinedIn,
+	loadAdrSlugMap,
 	makeHeadingIdsUnique,
 	mergeDefinedInIntoBlockquote,
+	mergeOverloadCallSignatures,
 	stripBreadcrumbs,
+	wrapDeprecatedCallout,
 } from '../../effects/api-pages'
 import { highlightCodeBlocks } from '../../html-shaping'
 import markdocConfig from '../../markdoc.config'
@@ -36,6 +41,30 @@ const renderApiUniqueIds = (markdown: string): string => {
 const renderApiTables = (markdown: string): string => {
 	const ast = Markdoc.parse(markdown)
 	const transformed = convertParameterSectionsToTables(
+		Markdoc.transform(ast, markdocConfig),
+	)
+	return Markdoc.renderers.html(transformed)
+}
+
+const renderApiCallouts = (markdown: string): string => {
+	const ast = Markdoc.parse(markdown)
+	const transformed = wrapDeprecatedCallout(
+		Markdoc.transform(ast, markdocConfig),
+	)
+	return Markdoc.renderers.html(transformed)
+}
+
+const renderApiOverloads = (markdown: string): string => {
+	const ast = Markdoc.parse(markdown)
+	const transformed = mergeOverloadCallSignatures(
+		Markdoc.transform(ast, markdocConfig),
+	)
+	return Markdoc.renderers.html(transformed)
+}
+
+const renderApiInheritedMembers = (markdown: string): string => {
+	const ast = Markdoc.parse(markdown)
+	const transformed = collapseInheritedMembers(
 		Markdoc.transform(ast, markdocConfig),
 	)
 	return Markdoc.renderers.html(transformed)
@@ -513,6 +542,364 @@ describe('makeHeadingIdsUnique', () => {
 			'<a href="#properties-bubbles"><code>bubbles</code></a>',
 		)
 		expect(html).not.toContain('href="#bubbles"')
+	})
+})
+
+/* === wrapDeprecatedCallout Tests === */
+
+describe('wrapDeprecatedCallout', () => {
+	test('wraps Deprecated content in a caution callout with a title', () => {
+		const html = renderApiCallouts(`##### initEvent()
+
+###### Deprecated
+
+[MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/initEvent)`)
+
+		expect(html).toContain('card-callout')
+		expect(html).toContain('caution')
+		expect(html).toContain('<strong>Deprecated</strong>')
+		expect(html).toContain('MDN Reference')
+		expect(html).not.toMatch(/<h6[^>]*>.*Deprecated.*<\/h6>/)
+	})
+
+	test('leaves Since untouched — card-callout has no quiet variant, so this stays plain text', () => {
+		const html = renderApiCallouts(`##### Since
+
+0.16.0`)
+
+		expect(html).not.toContain('card-callout')
+		expect(html).toMatch(/<h5[^>]*>.*Since.*<\/h5>/)
+		expect(html).toContain('0.16.0')
+	})
+
+	test('leaves a Deprecated heading with no body untouched', () => {
+		const html = renderApiCallouts(`##### Deprecated
+
+##### Throws
+
+If malformed`)
+
+		expect(html).not.toContain('card-callout')
+		expect(html).toMatch(/<h5[^>]*>.*Deprecated.*<\/h5>/)
+	})
+
+	test('leaves unrelated headings untouched', () => {
+		const html = renderApiCallouts(`##### Returns
+
+\`void\``)
+
+		expect(html).not.toContain('card-callout')
+	})
+})
+
+/* === mergeOverloadCallSignatures Tests === */
+
+describe('mergeOverloadCallSignatures', () => {
+	test('merges two Call Signature sections into a tab group', () => {
+		const html = renderApiOverloads(`### Function: createElementsMemo()
+
+#### Call Signature
+
+> **createElementsMemo**\\<\`S\`\\>(\`parent\`, \`selector\`)
+
+##### Returns
+
+\`Memo\`
+
+#### Call Signature
+
+> **createElementsMemo**\\<\`E\`\\>(\`parent\`, \`selector\`)
+
+##### Returns
+
+\`Memo\``)
+
+		expect(html).toContain('module-tabgroup')
+		expect(html).toContain('role="tablist"')
+		expect(html).toContain('Overload 1')
+		expect(html).toContain('Overload 2')
+		expect(html.match(/role="tabpanel"/g)).toHaveLength(2)
+		expect(html).not.toContain('Call Signature')
+	})
+
+	test('first tab is visible, subsequent tabs are hidden', () => {
+		const html = renderApiOverloads(`#### Call Signature
+
+Signature one
+
+#### Call Signature
+
+Signature two`)
+
+		const panels = [...html.matchAll(/<div role="tabpanel"[^>]*>/g)]
+		expect(panels).toHaveLength(2)
+		expect(panels[0]![0]).not.toContain('hidden')
+		expect(panels[1]![0]).toContain('hidden')
+	})
+
+	test('leaves a lone Call Signature (no overload) untouched', () => {
+		const html = renderApiOverloads(`### Function: foo()
+
+#### Call Signature
+
+> **foo**(): \`void\`
+
+##### Returns
+
+\`void\``)
+
+		expect(html).not.toContain('module-tabgroup')
+		expect(html).toContain('Call Signature')
+	})
+
+	test('handles an overload whose children clamp to a shallower level than the heading itself', () => {
+		// Mirrors composedPath() in ContextRequestEvent.md: an inherited DOM
+		// overload where "Call Signature" sits at h6 but its own "Returns"/
+		// "Inherited from" children render at h5 — shallower, not deeper.
+		const html = renderApiOverloads(`##### composedPath()
+
+###### Call Signature
+
+> **composedPath**(): \`EventTarget\`[]
+
+##### Returns
+
+\`EventTarget\`[]
+
+##### Inherited from
+
+\`Event.composedPath\`
+
+###### Call Signature
+
+> **composedPath**(): [\`EventTarget\`?]
+
+##### Returns
+
+[\`EventTarget\`?]
+
+##### Inherited from
+
+\`Event.composedPath\``)
+
+		expect(html).toContain('module-tabgroup')
+		expect(html.match(/role="tabpanel"/g)).toHaveLength(2)
+		expect(html).toContain('Inherited from')
+	})
+
+	test('gives distinct ids to tab groups from different overloaded methods on the same page', () => {
+		// A page with two separately-overloaded methods (e.g. ContextRequestEvent.md's
+		// composedPath() and preventDefault()) must not emit duplicate
+		// "panel_overload-1"/"panel_overload-2" ids across the two tab groups.
+		const html = renderApiOverloads(`##### composedPath()
+
+###### Call Signature
+
+Signature one
+
+###### Call Signature
+
+Signature two
+
+##### preventDefault()
+
+###### Call Signature
+
+Signature one
+
+###### Call Signature
+
+Signature two`)
+
+		const ids = [...html.matchAll(/id="([^"]+)"/g)].map(m => m[1])
+		expect(new Set(ids).size).toBe(ids.length)
+	})
+})
+
+/* === collapseInheritedMembers Tests === */
+
+describe('collapseInheritedMembers', () => {
+	test('splits inherited members into a collapsible, keeps own members inline', () => {
+		const html = renderApiInheritedMembers(`#### Properties
+
+##### context
+
+\`string\`
+
+The context key.
+
+##### bubbles
+
+\`boolean\`
+
+###### Inherited from
+
+\`Event.bubbles\``)
+
+		expect(html).toContain('card-collapsible')
+		expect(html).toContain('Inherited members (1)')
+		expect(html).toContain('The context key.')
+		// own member renders before the collapsible, inherited member inside it
+		const contextIndex = html.indexOf('context')
+		const collapsibleIndex = html.indexOf('card-collapsible')
+		expect(contextIndex).toBeLessThan(collapsibleIndex)
+		expect(html).toContain('bubbles')
+	})
+
+	test('leaves a section with no inherited members untouched', () => {
+		const html = renderApiInheritedMembers(`#### Properties
+
+##### context
+
+\`string\``)
+
+		expect(html).not.toContain('card-collapsible')
+	})
+
+	test('leaves sections other than Properties/Methods untouched', () => {
+		const html = renderApiInheritedMembers(`#### Extends
+
+- \`Error\``)
+
+		expect(html).not.toContain('card-collapsible')
+	})
+
+	test('finds inherited members nested inside an already-merged overload tab group', () => {
+		const merged = mergeOverloadCallSignatures(
+			Markdoc.transform(
+				Markdoc.parse(`#### Methods
+
+##### composedPath()
+
+###### Call Signature
+
+Signature one
+
+##### Inherited from
+
+\`Event.composedPath\`
+
+###### Call Signature
+
+Signature two
+
+##### Inherited from
+
+\`Event.composedPath\`
+
+##### own()
+
+Not inherited.`),
+				markdocConfig,
+			),
+		)
+		const transformed = collapseInheritedMembers(merged)
+		const html = Markdoc.renderers.html(transformed)
+
+		expect(html).toContain('card-collapsible')
+		expect(html).toContain('Inherited members (1)')
+		expect(html).toContain('module-tabgroup')
+		expect(html).toContain('Not inherited.')
+	})
+})
+
+/* === linkAdrReferences Tests === */
+
+describe('linkAdrReferences', () => {
+	test('links a known ADR reference', () => {
+		const content = 'isn’t Slot-backed. See ADR 0011.'
+		const result = linkAdrReferences(content, {
+			'0011': '0011-throw-on-pass-binding-failure',
+		})
+
+		expect(result).toBe(
+			'isn’t Slot-backed. See [ADR 0011](https://github.com/zeixcom/le-truc/blob/main/adr/0011-throw-on-pass-binding-failure.md).',
+		)
+	})
+
+	test('leaves an unknown ADR number untouched and warns', () => {
+		const warn = console.warn
+		let warned = false
+		console.warn = () => {
+			warned = true
+		}
+		try {
+			const content = 'See ADR 9999.'
+			expect(linkAdrReferences(content, {})).toBe(content)
+			expect(warned).toBe(true)
+		} finally {
+			console.warn = warn
+		}
+	})
+
+	test('links multiple references in the same document', () => {
+		const content = 'See ADR 0001. Elsewhere, See ADR 0002.'
+		const result = linkAdrReferences(content, {
+			'0001': '0001-foo',
+			'0002': '0002-bar',
+		})
+
+		expect(result).toContain(
+			'[ADR 0001](https://github.com/zeixcom/le-truc/blob/main/adr/0001-foo.md)',
+		)
+		expect(result).toContain(
+			'[ADR 0002](https://github.com/zeixcom/le-truc/blob/main/adr/0002-bar.md)',
+		)
+	})
+
+	test('leaves content without ADR references untouched', () => {
+		const content = 'No references here.'
+		expect(linkAdrReferences(content, {})).toBe(content)
+	})
+
+	test('links a lowercase "see" mention mid-sentence, inside parens', () => {
+		const content =
+			'activated yet — see ADR 0007). The request is therefore re-dispatched'
+		const result = linkAdrReferences(content, { '0007': '0007-foo' })
+
+		expect(result).toBe(
+			'activated yet — see [ADR 0007](https://github.com/zeixcom/le-truc/blob/main/adr/0007-foo.md)). The request is therefore re-dispatched',
+		)
+	})
+
+	test('links a reference with no trailing period, followed by more prose', () => {
+		const content = 'See ADR 0017 for full rationale (SSR adoption).'
+		const result = linkAdrReferences(content, { '0017': '0017-foo' })
+
+		expect(result).toBe(
+			'See [ADR 0017](https://github.com/zeixcom/le-truc/blob/main/adr/0017-foo.md) for full rationale (SSR adoption).',
+		)
+	})
+
+	test('links a reference followed by a closing paren and period, both left untouched', () => {
+		const content = 'see ADR 0003).'
+		const result = linkAdrReferences(content, { '0003': '0003-foo' })
+
+		expect(result).toBe(
+			'see [ADR 0003](https://github.com/zeixcom/le-truc/blob/main/adr/0003-foo.md)).',
+		)
+	})
+})
+
+/* === loadAdrSlugMap Tests === */
+
+describe('loadAdrSlugMap', () => {
+	test('maps known ADR numbers to their filename slug', async () => {
+		const map = await loadAdrSlugMap()
+
+		expect(map['0001']).toBe(
+			'0001-use-cause-effect-as-reactive-primitive-layer',
+		)
+		expect(Object.keys(map).length).toBeGreaterThan(0)
+	})
+
+	test('includes every numbered ADR file, including the template', () => {
+		return loadAdrSlugMap().then(map => {
+			expect(map['0000']).toBe('0000-template')
+			expect(map['0019']).toBe(
+				'0019-extension-based-dependency-injection-for-definecomponent',
+			)
+		})
 	})
 })
 

--- a/server/tests/effects/examples.test.ts
+++ b/server/tests/effects/examples.test.ts
@@ -30,4 +30,17 @@ describe('processExample', () => {
 		expect(result).toContain('<div class="preview">')
 		expect(result).not.toContain('preview-html=')
 	})
+
+	test('resolves the shared form-associated.md partial into a details/summary block', async () => {
+		const markdown = `### Demo\n\n{{ content }}\n\n{% partial file="form-associated.md" /%}`
+		const componentHtml = `<form-textbox></form-textbox>`
+
+		const result = await processExample('form-textbox', markdown, componentHtml)
+
+		expect(result).toContain('<card-collapsible>')
+		expect(result).toContain('<details>')
+		expect(result).toContain('class="description">Participates in HTML forms')
+		expect(result).toContain('checkValidity')
+		expect(result).toContain('willValidate')
+	})
 })

--- a/server/tests/schema/collapsible.test.ts
+++ b/server/tests/schema/collapsible.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit Tests for schema/collapsible.markdoc.ts — Collapsible Schema
+ *
+ * Tests for the collapsible Markdoc schema transformation: progressive
+ * disclosure rendered via the `<card-collapsible>` example component, which
+ * wraps a native `<details>`/`<summary>` element.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import Markdoc, { Node, Tag } from '@markdoc/markdoc'
+import collapsible from '../../schema/collapsible.markdoc'
+
+/* === Helpers === */
+
+const config = { tags: { collapsible } }
+
+function transformCollapsible(
+	attrs: Record<string, unknown>,
+	children: Node[] = [],
+): Tag {
+	const node = new Node('tag', attrs, children, 'collapsible')
+	return Markdoc.transform(node, config) as Tag
+}
+
+/* === Collapsible schema === */
+
+describe('collapsible schema', () => {
+	test('renders "card-collapsible" element', () => {
+		const result = transformCollapsible({ title: 'More info' })
+		expect(result).toBeInstanceOf(Tag)
+		expect(result.name).toBe('card-collapsible')
+	})
+
+	test('renders a native details/summary structure inside card-collapsible', () => {
+		const result = transformCollapsible({ title: 'More info' })
+		const details = result.children[0] as Tag
+		expect(details).toBeInstanceOf(Tag)
+		expect(details.name).toBe('details')
+
+		const summary = details.children[0] as Tag
+		expect(summary).toBeInstanceOf(Tag)
+		expect(summary.name).toBe('summary')
+	})
+
+	test('renders the title inside a summary > span.description', () => {
+		const result = transformCollapsible({ title: 'More info' })
+		const details = result.children[0] as Tag
+		const summary = details.children[0] as Tag
+		const description = summary.children[0] as Tag
+		expect(description).toBeInstanceOf(Tag)
+		expect(description.name).toBe('span')
+		expect(description.attributes.class).toBe('description')
+		expect(description.children[0]).toBe('More info')
+	})
+
+	test('renders transformed children inside a div.content sibling of summary', () => {
+		const child = new Node('paragraph', {}, [
+			new Node('text', { content: 'Hidden content' }),
+		])
+		const result = transformCollapsible({ title: 'More info' }, [child])
+		const details = result.children[0] as Tag
+		const content = details.children[1] as Tag
+		expect(content).toBeInstanceOf(Tag)
+		expect(content.name).toBe('div')
+		expect(content.attributes.class).toBe('content')
+		expect(content.children.length).toBeGreaterThan(0)
+		const paragraph = content.children[0] as Tag
+		expect(paragraph).toBeInstanceOf(Tag)
+		expect(paragraph.name).toBe('p')
+	})
+
+	test('requires a title attribute', () => {
+		const node = new Node('tag', {}, [], 'collapsible')
+		const errors = Markdoc.validate(node, config)
+		expect(errors.length).toBeGreaterThan(0)
+	})
+
+	test('allows a table as a direct child without validation errors', () => {
+		const table = new Node('table', {}, [], 'table')
+		const node = new Node('tag', { title: 'More info' }, [table], 'collapsible')
+		const errors = Markdoc.validate(node, config)
+		expect(errors).toEqual([])
+	})
+})

--- a/src/helpers/reactive.ts
+++ b/src/helpers/reactive.ts
@@ -176,12 +176,12 @@ const activateResult = (result: FactoryResult): void => {
  * so it is still visited here — the only path that picks it up.
  *
  * @since 2.3
- * @param {FactoryResult | EffectDescriptor | Falsy} result - Flat or nested array, single descriptor, or falsy value to reconcile
+ * @param {FactoryResult | EffectDescriptor | Falsy | void} result - Flat or nested array, single descriptor, falsy value, or nothing to reconcile
  * @param {ReadonlySet<EffectDescriptor>} seen - Descriptors already accounted for (by reference) — skipped
  * @param {(descriptor: EffectDescriptor) => void} visit - Called once per not-yet-seen descriptor, in encounter order
  */
 const forEachUnseen = (
-	result: FactoryResult | EffectDescriptor | Falsy,
+	result: FactoryResult | EffectDescriptor | Falsy | void,
 	seen: ReadonlySet<EffectDescriptor>,
 	visit: (descriptor: EffectDescriptor) => void,
 ): void => {
@@ -509,7 +509,7 @@ const makePass = <P extends ComponentProps>(
  */
 function each<E extends Element>(
 	memo: Memo<E[]>,
-	callback: (element: E) => FactoryResult | EffectDescriptor | Falsy,
+	callback: (element: E) => FactoryResult | EffectDescriptor | Falsy | void,
 ): EffectDescriptor {
 	const descriptor: EffectDescriptor = () => {
 		keyedScopes(memo, element => {

--- a/types/src/helpers/reactive.d.ts
+++ b/types/src/helpers/reactive.d.ts
@@ -94,11 +94,11 @@ declare const activateResult: (result: FactoryResult) => void;
  * so it is still visited here — the only path that picks it up.
  *
  * @since 2.3
- * @param {FactoryResult | EffectDescriptor | Falsy} result - Flat or nested array, single descriptor, or falsy value to reconcile
+ * @param {FactoryResult | EffectDescriptor | Falsy | void} result - Flat or nested array, single descriptor, falsy value, or nothing to reconcile
  * @param {ReadonlySet<EffectDescriptor>} seen - Descriptors already accounted for (by reference) — skipped
  * @param {(descriptor: EffectDescriptor) => void} visit - Called once per not-yet-seen descriptor, in encounter order
  */
-declare const forEachUnseen: (result: FactoryResult | EffectDescriptor | Falsy, seen: ReadonlySet<EffectDescriptor>, visit: (descriptor: EffectDescriptor) => void) => void;
+declare const forEachUnseen: (result: FactoryResult | EffectDescriptor | Falsy | void, seen: ReadonlySet<EffectDescriptor>, visit: (descriptor: EffectDescriptor) => void) => void;
 /**
  * Drive per-element scopes from a `Memo<E[]>` with element-identity keying.
  *
@@ -170,7 +170,7 @@ declare const makePass: <P extends ComponentProps>(host: HTMLElement & P) => Pas
  *
  * @since 2.0
  */
-declare function each<E extends Element>(memo: Memo<E[]>, callback: (element: E) => FactoryResult | EffectDescriptor | Falsy): EffectDescriptor;
+declare function each<E extends Element>(memo: Memo<E[]>, callback: (element: E) => FactoryResult | EffectDescriptor | Falsy | void): EffectDescriptor;
 /**
  * Sync a keyed reactive data source to a container's children.
  *


### PR DESCRIPTION
### Fixed

- **`each()` callback type omitted `void`**: `each()`'s contract expects callbacks to call `watch()`/`on()`/`pass()` directly without returning anything — the idiomatic void-returning form. This compiled under TypeScript 6.x by accident: a callback with no `return` statement implicitly returns `undefined`. It does not hold under TypeScript 7, which infer the no-return case as literal `void` — not assignable to `Falsy` even though `undefined` is. The callback type is now `FactoryResult | EffectDescriptor | Falsy | void`.